### PR TITLE
feat: Improve attachment handling and conversion robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,12 @@ venv/
 *.json
 profile.html
 misc/
+
+# Local data, config, and logs
+en_backup.db
+config.json
+*.log
+
+# Output folders
+md/
+html/

--- a/evernote2md.py
+++ b/evernote2md.py
@@ -567,10 +567,15 @@ class EvernoteHTMLToMarkdownConverter:
             else:
                 # If next node is a <div>, <p> or <br>, add a new line, otherwise add a space
                 nl = "\n" if node.next_sibling and node.next_sibling.name in block_level_elements else " "
-                if (width):
-                    width  = int(float(width.strip("px")))
-                    result = f'{preview}[[{file_path}\\|{width}]]{nl}'
-                else: result = f'{preview}{result}{nl}'
+                if width:
+                    try:
+                        width_val = int(float(width.strip("px")))
+                        result = f'{preview}[[{file_path}\\|{width_val}]]{nl}'
+                    except ValueError:
+                        # Width is not a valid number (e.g., "auto"), so don't specify it
+                        result = f'{preview}{result}{nl}'
+                else:
+                    result = f'{preview}{result}{nl}'
         else:
             pass
             #self.warnings.append(f"Unsupported media type: {type_}")

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -1084,7 +1084,7 @@ class Exporter_HTML(Exporter):
             return f'"{path}"'
 
         content = re.sub(r'<en-media ([^>]+)\s*/>', subs_en_media, content)
-        content = re.sub('"(?:evernote:///view/[^/]+/[^/]+/(.+?)/.+?|https://share.evernote.com/note/(.+?))"', subs_href, content)
+        content = re.sub(r'"(?:evernote:///view/[^/]+/[^/]+/(.+?)/.+?|https://share.evernote.com/note/(.+?))"', subs_href, content)
         return content, errors
 
 

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -866,7 +866,7 @@ class Exporter:
                     # Create a unique full relative path for the attachment
                     full_attachment_path_rel = posix_join(notebook_path_rel, attachment_folder_rel, fn)
                     unique_full_path_rel     = get_unique_filename(full_attachment_path_rel, filenames_set)
-                    attachment_path_rel      = os.path.relpath(unique_full_path_rel, notebook_path_rel) # Path relative to note
+                    attachment_path_rel      = to_posix(os.path.relpath(unique_full_path_rel, notebook_path_rel)) # Path relative to note
                     attachment_path_abs      = posix_join(self.output_folder, unique_full_path_rel)
 
                     fn = os.path.split(attachment_path_abs)[-1]
@@ -954,6 +954,7 @@ class Exporter:
                     attachment_path_abs = guid_to_path_abs[resource.guid]
 
                     # Save attachment file
+                    os.makedirs(os.path.dirname(attachment_path_abs), exist_ok=True)
                     if not cfg["overwrite"] and os.path.exists(attachment_path_abs):
                         log(logging.WARNING, f"    - Skipping, already exists: {attachment_path_abs}")
                     else:

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -883,7 +883,7 @@ class Exporter:
                     path_to_guid[attachment_path_rel] = resource.guid
                     guid_to_path_rel[resource.guid]   = attachment_path_rel
                     guid_to_path_abs[resource.guid]   = attachment_path_abs
-                    hash = int.from_bytes(resource.data.bodyHash) # Better int than .hex().zfill(32) ?
+                    hash = int(resource.data.bodyHash.hex(), 16)
                     # TO-DO:
                     #  - Can we have one hash for two different files?
                     #  - What should we do if we have the same file in multiple places?

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -22,7 +22,7 @@ import json
 import lzma
 import pickle
 import logging
-import sqlite3
+import sqlite3  
 import mimetypes
 from   bs4         import BeautifulSoup
 from   typing      import Sequence, TypeVar
@@ -863,11 +863,11 @@ class Exporter:
                     #   - In case of HTML files, use "correct" format ([html file without ext]_files) ?
                     # - We're also not checking if there are links to each/all attachment in the note content. But should we?
                     attachment_folder_rel = "_resources"
-                    attachment_folder_abs = posix_join(notebook_path_abs, attachment_folder_rel)
-                    os.makedirs(attachment_folder_abs, exist_ok=True)
-                    attachment_path_rel   = posix_join(attachment_folder_rel, fn)
-                    attachment_path_rel   = get_unique_filename(attachment_path_rel, filenames_set)
-                    attachment_path_abs   = posix_join(notebook_path_abs, attachment_path_rel)
+                    # Create a unique full relative path for the attachment
+                    full_attachment_path_rel = posix_join(notebook_path_rel, attachment_folder_rel, fn)
+                    unique_full_path_rel     = get_unique_filename(full_attachment_path_rel, filenames_set)
+                    attachment_path_rel      = os.path.relpath(unique_full_path_rel, notebook_path_rel) # Path relative to note
+                    attachment_path_abs      = posix_join(self.output_folder, unique_full_path_rel)
 
                     fn = os.path.split(attachment_path_abs)[-1]
                     if resource.attributes.fileName and fn != resource.attributes.fileName:
@@ -879,7 +879,7 @@ class Exporter:
                     #     # Use RELATIVE paths in attachment_path if converting to Markdown or to HTML files
                     #     # Use ABSOLUTE paths in attachment_path if converting to .md files in HTML format
                     #     attachment_path_rel = attachment_path_abs
-                    filenames_set.add(attachment_path_rel.lower())
+                    filenames_set.add(unique_full_path_rel.lower())
                     path_to_guid[attachment_path_rel] = resource.guid
                     guid_to_path_rel[resource.guid]   = attachment_path_rel
                     guid_to_path_abs[resource.guid]   = attachment_path_abs

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -1047,8 +1047,8 @@ class Exporter_HTML(Exporter):
         def subs_en_media(regex_match) -> str:
             en_media = regex_match[1]
             result = en_media
-            type_  = re.findall('type="([^"]+)"', en_media)[0]
-            hash   = int(re.findall('hash="([^"]+)"', en_media)[0], 16)
+            type_  = (re.findall('type="([^"]+)"', en_media) or [""])[0]
+            hash   = int((re.findall('hash="([^"]+)"', en_media) or ["0"])[0], 16)
             if not (path := hash_to_path.get(hash)):
                 log(logging.ERROR, f"    - [ERROR] Path to media hash not found: {hash}")
                 path = hash


### PR DESCRIPTION
This pull request introduces a series of critical bug fixes and robustness improvements to the export and conversion process. The primary focus is on correcting how attachments are handled to prevent data loss and broken links, while also making the script more resilient to duplicated content and attachments in Evernote.

Note: The patches in this pull request were developed in collaboration with Gemini Code Assist. All changes were reviewed and verified before being committed. I used my Evernote environment (is pile the right word if it was collected over 14 years?) of 2664 notes, which resulted in 4,329 Files, 15 Folders, for testing.

Key Changes:
**Corrected Shared Attachment Linking:**

Resolves a major logical flaw where attachments shared across multiple notes would have broken links. The script now tracks each instance of an attachment, ensuring links are always correct for the specific note being processed.

**Fixed Attachment Renaming Logic:**

Prevents the unnecessary renaming of attachments that have the same name but reside in different notebook directories. The uniqueness check is now correctly based on the full vault-relative path.

**Ensured Cross-Platform Path Compatibility:**

Fixes an issue where attachment links on Windows were generated with backslashes (\) instead of the forward slashes (/) required by Obsidian. All paths are now normalized to the POSIX format.
Robust Image Width Parsing:

Prevents the conversion process from crashing due to a ValueError when an image has a non-numeric width attribute (e.g., "auto"). The script now gracefully handles this by creating a standard image link without a width specifier.

**Improved Contributor Workflow:**

Adds to the .gitignore file to exclude local data, configuration, logs, and output directories,.
These changes collectively make the evernote2obsidian tool more reliable for converting piles of old notes, leading to a much smoother migration experience.