### PR TITLE
Improve Obsidian Markdown conversion with new features, bug fixes, and code quality

### DIFF
--- a/evernote2md.py
+++ b/evernote2md.py
@@ -19,11 +19,12 @@
 __version__ = "0.1.7"
 __author__  = "AltoRetrato"
 
+import logging
 import os
 import re
 from   bs4         import BeautifulSoup
 from   typing      import List, Tuple, Dict
-from   statistics  import mode
+from   statistics  import mode, StatisticsError
 from   collections import Counter
 
 
@@ -47,13 +48,19 @@ class EvernoteHTMLToMarkdownConverter:
     def convert_html_to_markdown(
             self,
             html_content: str,
-            md_properties: List = [],
-            tasks: Dict = {},
-            guid_to_path: Dict = {},
-            hash_to_path: Dict = {},
-            options:      Dict = {},
+            md_properties: List  = None,
+            tasks: Dict         = None,
+            guid_to_path: Dict  = None,
+            hash_to_path: Dict  = None,
+            options:      Dict  = None,
             ) -> Tuple[str, List]:
         """ Convert HTML content to Markdown format. """
+
+        if md_properties is None: md_properties = []
+        if tasks is None:         tasks = {}
+        if guid_to_path is None:  guid_to_path = {}
+        if hash_to_path is None:  hash_to_path = {}
+        if options is None:       options = {}
 
         self.tasks        = tasks        # dict. for tasks (provided by caller)
         self.guid_to_path = guid_to_path # dict. for links (provided by caller)
@@ -64,7 +71,7 @@ class EvernoteHTMLToMarkdownConverter:
         self.list_stack    = []
         self.indent_level  = 0        # used in lists, list items
         self.number_indent = {}       # used in ordered lists
-        self.warnings      = []       # list of warnings returned after conversion
+        self.warnings      = []       # list of (level, message) tuples returned after conversion
         self.inside_pre    = False    # True if processing content that should not be escaped
         self.inside_table  = False    # True if processing a table
 
@@ -75,6 +82,15 @@ class EvernoteHTMLToMarkdownConverter:
         for element in self.soup(['script', 'style']):
             element.decompose()
 
+        if self.options.get("hr_as_h1", False):
+            self._promote_hr_to_h1()
+
+        if self.options.get("normalize_heading_levels", True):
+            self._normalize_heading_levels()
+
+        if self.options.get("bold_as_heading", False):
+            self._promote_bold_to_heading()
+
         # Convert to markdown
         markdown = self._process_node(self.soup)
 
@@ -83,15 +99,15 @@ class EvernoteHTMLToMarkdownConverter:
             properties = ["---"] + md_properties + ["---\n"]
             markdown = '\n'.join(properties) + markdown
 
-        # Return a short(er) list of warnings
+        # Return a short(er) list of (level, message) warnings
         counter = Counter(self.warnings)
         sorted_warnings = sorted(
             counter.items(),
-            key=lambda x: (-x[1], x[0]) # First by count (descending), then by name (ascending)
+            key=lambda x: (-x[1], x[0][1]) # First by count (descending), then by message (ascending)
         )
         warnings = [
-            f"{item} [{count}x]" if count > 1 else item
-            for item, count in sorted_warnings
+            (level, f"{msg} [{count}x]") if count > 1 else (level, msg)
+            for (level, msg), count in sorted_warnings
         ]
 
         return markdown, warnings
@@ -160,7 +176,7 @@ class EvernoteHTMLToMarkdownConverter:
 
     def _use_html(self, html: str) -> bool:
         """Helper function that checks if HTML should be used or not (and warns in each case)."""
-        self.warnings.append(f"{'Added' if self.use_html else 'Removed'} unsupported HTML: {html}")
+        self.warnings.append((logging.INFO, f"{'Added' if self.use_html else 'Removed'} unsupported HTML: {html}"))
         return self.use_html
 
     def _process_div(self, node) -> str:
@@ -172,18 +188,19 @@ class EvernoteHTMLToMarkdownConverter:
         if "--en-tableofcontents:true" in style:
             # Shouldn't be too hard to implement, but might just not be worth it
             # since Obsidian can show a note outline in the right side bar.
-            self.warnings.append("Ignored Table of Contents (conversion not implemented)")
-            result = '==Evernote Table of Contents removed during conversion! In Obsidian, use "Open linked view" > "Open outline" instead.=='
+            self.warnings.append((logging.INFO, "Ignored Table of Contents (conversion not implemented)"))
+            return ""
         # Code block
         elif "--en-codeblock:true" in style:
             language = (re.findall("--en-syntaxLanguage:(.+?);", style) or [""])[0]
             result = f"```{language}\n{result}```"
         # Tasks
         elif "--en-task-group:true" in style:
-            id = re.findall("--en-id:([0-9a-f-]+);", style)[0]
-            if self.tasks and id in self.tasks:
-                  result = self.tasks[id]
-            else: result = f"- [ ] ==Could not find task(s) ID {id} during conversion=="
+            ids = re.findall("--en-id:([0-9a-f-]+);", style)
+            task_id = ids[0] if ids else None
+            if self.tasks and task_id and task_id in self.tasks:
+                  result = self.tasks[task_id]
+            else: return ""  # Empty task group (no tasks in database) — skip
         else:
 
             # Text alignment not supported in Markdown, but we can use some HTML...
@@ -210,10 +227,18 @@ class EvernoteHTMLToMarkdownConverter:
             #         Workaround: use a bullet list (works even if you set it on just the 1s line!).
             padding_left = re.findall(r"(?:padding|margin)-left\s*:\s*(\d+)\s*px", style)
             if padding_left:
-                indent = "    " * (int(padding_left[0])//40)
+                indent = "  " * (int(padding_left[0])//40)
                 result = f'{indent}{result}'
                 # If list item has \n in the content, add indent
                 result = result.replace("\n", f"\n{indent}")
+
+            # Collapse leading non-breaking / regular spaces to max 3 to avoid
+            # accidental code blocks (4+ spaces after a blank line = code).
+            stripped = result.lstrip(' \xa0')
+            leading = len(result) - len(stripped)
+            if leading >= 4:
+                indent = "  " * (leading // 5 or 1)
+                result = indent + stripped
 
         # An empty line in Evernote is a <div><br/></div>, which could create
         # a double line break in Markdown. So we strip any trailing new line.
@@ -262,11 +287,11 @@ class EvernoteHTMLToMarkdownConverter:
                         "^(evernote:///|https://www.evernote.com/|https://share.evernote.com/note/).+",
                         node.parent.get("href", "")
                     )
-                    if (   style == 'color:rgb(105, 170, 53);' # Green/yellowish color of internal links
-                        or style == "color:rgb(24, 168, 65);--inversion-type-color:simple;" # Green color
-                        and internal_link
-                        and self.options.get("remove_green_link", True)):
-                            pass # don't add color
+                    if (internal_link
+                        and self.options.get("remove_green_link", True)
+                        and style in ('color:rgb(105, 170, 53);',
+                                      'color:rgb(24, 168, 65);--inversion-type-color:simple;')):
+                            pass  # green internal-link color — strip it
                     elif self._use_html("text color / color:rgb"):
                         content = f'<span style="{style}">{content}</span>'
 
@@ -284,7 +309,8 @@ class EvernoteHTMLToMarkdownConverter:
 
         # If we are formatting an external link, format only the anchor text
         url, lf = None, None
-        if node.next and node.next.name == "a" and not content.startswith("[["):
+        nxt = node.find_next_sibling()
+        if nxt and nxt.name == "a" and not content.startswith("[["):
             if (parts := re.findall(r'^\[(.*?)\]\((.*?)\)(.*)$', content, flags=re.S) ):
                 content, url, lf = parts[0]
 
@@ -301,7 +327,11 @@ class EvernoteHTMLToMarkdownConverter:
         elif node.name in ("s", "del"):
             result = f'{space_begin}~~{stripped_content}~~{space_end}'
         elif node.name == "blockquote":
-            result = f"> " + "\n> ".join(stripped_content.split("\n")) + "\n"
+            quoted_lines = ['> [!quote] ']
+            for line in stripped_content.split('\n'):
+                s = line.rstrip()
+                quoted_lines.append(f'> {s}' if s else '>')
+            result = '\n'.join(quoted_lines) + '\n\n'
         elif node.name == "code":
             if "\n" in content:
                   result = f'```\n{content}\n```\n'
@@ -320,7 +350,10 @@ class EvernoteHTMLToMarkdownConverter:
         """Convert HTML headers to Markdown headers."""
         level = int(node.name[1])
         content = self._process_node_children(node)
-        return f'{"#" * level} {content}\n'
+        stripped = content.strip().replace("**", "")
+        if not stripped:
+            return ""
+        return f'{"#" * level} {stripped}\n'
 
     def _process_checkbox(self, node) -> str:
         """Convert Evernote to-do checkboxes to Markdown."""
@@ -333,10 +366,14 @@ class EvernoteHTMLToMarkdownConverter:
 
     def _process_list(self, node) -> str:
         """Process ordered and unordered lists."""
-        self.list_stack.append(node.name)
-        self.indent_level += 1
-        if node.name == "ol":
-            self.number_indent[self.indent_level] = 0
+        has_direct_items = any(
+            child.name == "li" for child in node.children if hasattr(child, "name")
+        )
+        if has_direct_items:
+            self.list_stack.append(node.name)
+            self.indent_level += 1
+            if node.name == "ol":
+                self.number_indent[self.indent_level] = int(node.get("start", 1)) - 1
 
         result = ''
         # If there is a <ul> or <ol> inside a <li>, add a new line at the start
@@ -345,8 +382,9 @@ class EvernoteHTMLToMarkdownConverter:
         for child in node.children:
             result += self._process_node(child)
 
-        self.indent_level -= 1
-        self.list_stack.pop()
+        if has_direct_items:
+            self.indent_level -= 1
+            self.list_stack.pop()
         return result
 
     def _process_list_item(self, node) -> str:
@@ -373,7 +411,8 @@ class EvernoteHTMLToMarkdownConverter:
         """Convert HTML table to Markdown table."""
         # We can't converted nested tables. In that case, just return the HTML.
         if node.find("table"):
-            self.warnings.append("Nested tables are not supported, returning HTML")
+            level = logging.INFO if self._is_web_clip_note() else logging.WARNING
+            self.warnings.append((level, "Nested tables are not supported, returning HTML"))
             return str(node)
 
         # Convert HTML table to Markdown table.
@@ -428,7 +467,8 @@ class EvernoteHTMLToMarkdownConverter:
                         col_num += 1
                 # Adjust row_spans at the end of a row, if needed
                 for x in range(col_num, max_cols):
-                    row_spans[x] -= 1
+                    if row_spans[x] > 0:
+                        row_spans[x] -= 1
 
             row_num += 1
 
@@ -439,17 +479,29 @@ class EvernoteHTMLToMarkdownConverter:
 
         # Step 5: Add separators / column alignments
         if result:
-            # Use the most common ("mode") alignment of each column as separator
-            separators = [mode([grid[r][c]["align"] for r in range(len(grid))]) for c in range(max_cols)]
+            def _safe_mode(values, default=LEFT):
+                try:
+                    return mode(values)
+                except StatisticsError:
+                    return default
+            separators = [_safe_mode([grid[r][c]["align"] for r in range(len(grid))]) for c in range(max_cols)]
             result.insert(1, f"| {' | '.join(separators)} |")
 
         self.inside_table = False
         return "\n" + "\n".join(result) + "\n"
 
+    _unicode_spaces = re.compile(r'[\u00A0\u2007\u202F\u2060\uFEFF]+')
+
+    def _is_web_clip_note(self) -> bool:
+        """Return True when converting content from a web clip note."""
+        return bool(self.options.get("_is_web_clip_note", False))
+
     def _process_link(self, node) -> str:
         """Convert HTML links to Markdown links."""
-        content = self._process_node_children(node)
+        content = self._unicode_spaces.sub(' ', self._process_node_children(node))
         href    = node.get('href', '')
+        # Prevent accidental Obsidian ==highlight== parsing inside link labels.
+        content = content.replace("==", r"\=\=")
         # https://help.obsidian.md/syntax#Escape+blank+spaces+in+links
         # (even though spaces in Evernote links are already escaped with %20)
         if " " in href:
@@ -462,7 +514,7 @@ class EvernoteHTMLToMarkdownConverter:
         # Linked note - preview
         #   <div style="--en-richlink:true; --en-href:[...]; --en-title:[...]; --en-viewAs:evernote-note-snippet-preview;[...]">
         #   <a href="[...]" rev="en_rl_small">A linked note</a></div>
-        preview = "!" if "evernote-note-snippet-preview" in node.parent.get("style","") else ""
+        preview = ""
         escape  = "\\" if self.inside_table else ""
 
         style = None
@@ -480,15 +532,24 @@ class EvernoteHTMLToMarkdownConverter:
            or (guid := re.match("https://www.evernote.com/[^/]+/[^/]+/[^/]+/[^/]+/([0-9a-f-]+)", href)) \
            or (guid := re.match("https://share.evernote.com/note/(.+)", href)):
             if not (path := self.guid_to_path.get(guid[1])):
-                path = content
-                self.warnings.append(f"Path to link GUID not found: {guid[1]} ({content})")
+                deleted_guid_to_title = self.options.get("_deleted_guid_to_title", {})
+                if deleted_guid_to_title.get(guid[1]):
+                    path = deleted_guid_to_title[guid[1]]
+                    path = self._unicode_spaces.sub(' ', path).strip()
+                    path = path.replace('|', ' - ').replace('[', '(').replace(']', ')')
+                    self.warnings.append((logging.INFO, f"Path to link GUID not found in active export, using deleted note title: {guid[1]} ({path})"))
+                else:
+                    path = content
+                    self.warnings.append((logging.WARNING, f"Path to link GUID not found: {guid[1]} ({content})"))
+            # Remove .md extension from path for internal links
+            path_without_ext = path[:-3] if path.lower().endswith('.md') else path
             # Escaping links can get ugly pretty quickly...
             # At this point, square brackets were already escaped,
             # but they don't need to be for internal links, so we remove them...
             content = content.replace(r"\[", "[").replace(r"\]", "]")
             if style:
-                  return f'<span style="{style}">{preview}[[{path}{escape}|{content}]]</span>'
-            else: return f'{preview}[[{path}{escape}|{content}]]'
+                  return f'<span style="{style}">{preview}[[{path_without_ext}{escape}]]</span>'
+            else: return f'{preview}[[{path_without_ext}{escape}]]'
 
         # Return external link
         if style:
@@ -506,13 +567,94 @@ class EvernoteHTMLToMarkdownConverter:
         title = node.get('title', '') 
         if src.startswith("data:image"):
             # Base64 images are exported with <img> tag
-            self.warnings.append(f"Added base64 image")
+            self.warnings.append((logging.INFO, "Added base64 image"))
             alt_   = f' alt="{alt}"'     if alt   else ""
             title_ = f' title="{title}"' if title else ""
             return f'<img src="{src}"{alt_}{title_} />'
         if src.startswith('/'):
             src = f'./_resources{src}'
         return f'![{title or alt}]({src})'
+
+    def _promote_hr_to_h1(self):
+        """Replace <div>text</div><hr/> with <h1>text</h1> in the parsed soup."""
+        for hr in list(self.soup.find_all('hr')):
+            prev = hr.find_previous_sibling()
+            if not prev or prev.name != 'div':
+                continue
+            text = prev.get_text(strip=True)
+            if not text or prev.find(['div', 'table', 'ul', 'ol', 'en-media', 'img']):
+                continue
+            nxt = hr.find_next_sibling()
+            h1 = self.soup.new_tag('h1')
+            h1.string = text
+            prev.replace_with(h1)
+            hr.decompose()
+            if nxt and nxt.name and not nxt.get_text(strip=True):
+                nxt.decompose()
+
+    @staticmethod
+    def _is_bold_element(tag):
+        """Check if a tag is visually bold (<b>, <strong>, or font-weight:bold span)."""
+        if not hasattr(tag, 'name'):
+            return False
+        if tag.name in ('b', 'strong'):
+            return True
+        if tag.name == 'span':
+            style = tag.get('style', '')
+            if 'font-weight' in style and ('bold' in style or '700' in style):
+                return True
+        return False
+
+    def _promote_bold_to_heading(self):
+        """In notes with no headings, convert bold-only divs to heading tags."""
+        if self.soup.find(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
+            return
+        for div in list(self.soup.find_all('div')):
+            children = [c for c in div.children if str(c).strip()]
+            if len(children) != 1:
+                continue
+            child = children[0]
+            if not self._is_bold_element(child):
+                continue
+            text = child.get_text(strip=True)
+            if not text or len(text) > 80:
+                continue
+            h1 = self.soup.new_tag('h1')
+            h1.string = text
+            div.replace_with(h1)
+
+    def _normalize_heading_levels(self):
+        """Close gaps in heading hierarchy (e.g. h1→h3 becomes h1→h2)."""
+        headings = self.soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+        if not headings:
+            return
+        prev_orig = 0
+        prev_new  = 0
+        level_map = {}
+        for h in headings:
+            orig = int(h.name[1])
+            if orig < prev_orig:
+                level_map = {k: v for k, v in level_map.items() if k <= orig}
+            if orig in level_map:
+                new = level_map[orig]
+            elif orig > prev_new + 1:
+                new = prev_new + 1
+                level_map[orig] = new
+            else:
+                new = orig
+            prev_orig = orig
+            prev_new  = new
+            if new != orig:
+                h.name = f'h{new}'
+
+    @staticmethod
+    def _has_adjacent_pdf(node) -> bool:
+        """Check if the previous or next sibling is also a PDF en-media tag."""
+        for sibling in (node.previous_sibling, node.next_sibling):
+            if (sibling and sibling.name == "en-media"
+                    and "application/pdf" in sibling.get("type", "")):
+                return True
+        return False
 
     def _process_media(self, node) -> str:
         """Convert Evernote media to Obsidian Markdown."""
@@ -524,12 +666,20 @@ class EvernoteHTMLToMarkdownConverter:
             # Seems like Evernote Web Clips (sometimes? always?) ends with these "empty" media notes:
             # <br/><en-media hash="" type="" /><br/><en-media hash="" type="text/html" />
             # See https://github.com/AltoRetrato/evernote2obsidian/issues/17
-            self.warnings.append(f"Media node without hash: {node}")
+            self.warnings.append((logging.WARNING, f"Media node without hash: {node}"))
             return ""
-        hash_int = int(hash_hex, 16)
-        if not (file_path := self.hash_to_path.get(hash_int)):
+        # Handle UUID format hashes (with hyphens) by removing them
+        hash_hex_clean = hash_hex.replace("-", "")
+        try:
+            hash_int = int(hash_hex_clean, 16)
+        except ValueError:
+            hash_int = None
+        if hash_int is not None and (file_path := self.hash_to_path.get(hash_int)):
+            pass
+        else:
             file_path = hash_hex
-            self.warnings.append(f"Path to media hash not found: {hash_hex}")
+            level = logging.INFO if self._is_web_clip_note() else logging.WARNING
+            self.warnings.append((level, f"Path to media hash not found: {hash_hex}"))
             # TO-DO: this happened on a few (4?) notes where the media hash
             # in <resource> and <en-media> where different (Evernote bug?).
             # It could be interesting to list <resource>
@@ -554,8 +704,11 @@ class EvernoteHTMLToMarkdownConverter:
             # as an attachment, so we disable the preview.
             if not style and "autopx" in node.get("height", ""):
                 preview = ""
-            pdf_view    = self.options.get("pdf_view", "default")
-            pdf_preview = {"default": preview, "title": "", "preview": "!"}.get(pdf_view, preview)
+            pdf_view    = self.options.get("pdf_view", "hybrid")
+            if pdf_view == "hybrid":
+                pdf_preview = "" if self._has_adjacent_pdf(node) else preview
+            else:
+                pdf_preview = {"default": preview, "title": "", "preview": "!"}.get(pdf_view, preview)
             result  = f"{pdf_preview}{result}\n"
         elif type_.startswith("image/"):
             width = node.get("width","")
@@ -575,7 +728,7 @@ class EvernoteHTMLToMarkdownConverter:
                     else: result = f'<div style="text-align: right;"><img src="{file_path}"></div>\n'
                     # <img src="..." style="display: block; margin-left: auto; margin-right: 0;">
             elif ("--en-imageAlignment:fullWidth" in style and
-                  self._use_html("image alignment (right)")):
+                  self._use_html("image alignment (fullWidth)")):
                     result = f'<img src="{file_path}" style="width: 100%;">\n'
             else:
                 # If next node is a <div>, <p> or <br>, add a new line, otherwise add a space
@@ -589,9 +742,12 @@ class EvernoteHTMLToMarkdownConverter:
                         result = f'{preview}{result}{nl}'
                 else:
                     result = f'{preview}{result}{nl}'
-        else:
-            pass
-            #self.warnings.append(f"Unsupported media type: {type_}")
+        elif type_ == "application/octet-stream":
+            _IMAGE_EXTS = {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg', '.webp', '.tiff', '.tif', '.ico'}
+            ext = os.path.splitext(file_name)[1].lower()
+            if ext in _IMAGE_EXTS:
+                nl = "\n" if node.next_sibling and node.next_sibling.name in block_level_elements else " "
+                result = f'{preview}{result}{nl}'
         return result
 
     def _process_node_children(self, node) -> str:
@@ -615,10 +771,6 @@ class EvernoteHTMLToMarkdownConverter:
         # Escape all _ preceeded by nothing or a space and followed by a non-space character
         part = re.sub(r"(^|\s)([_]+)(?=\S)", lambda m: m.group(1) + "\\" + "\\".join(m.group(2)), part)
 
-        # Escape instances of * _ when they are followed by a non-space character
-        # Works in editing mode, but not always in reading mode (e.g., "1 * 2 * 3")
-        # text = re.sub(r"([*_^]+)(\S)", lambda m: "\\" + "\\".join(m.group(1)) + m.group(2), text)
-
         # Escape "%%"
         part = part.replace("%%", "%\\%")
 
@@ -634,21 +786,11 @@ class EvernoteHTMLToMarkdownConverter:
         # Escape sequences of two or more = ~ followed by a non-space character
         part = re.sub(r"([=~]{2,})(?=\S)", lambda m: "\\" + "\\".join(m.group(1)), part)
 
-        # Escape sequences of three or more - *
-        #text = re.sub("([-*]{3,})", lambda m: "\\" + "\\".join(m.group(1)), text)
-
         # Escape - + = > # | when they appear at the start of a line (even if preceeded by spaces)
         part = re.sub(r"(?m)^(\s*)([\-+=>#|])", r"\1\\\2", part)
 
         # Escape ordered / numbered lists (e.g.: 1. ... => 1\. ...)
         part = re.sub(r"(?m)^(\s*\d+)(\.\s+)", r"\1\\\2", part)
-
-        # If not escaping $ above / previously, these two regexes
-        # give a better result when using only editing view.
-        # # Escape single dollar signs pair to avoid inline math
-        # part = re.sub(r"\$(?!\s)([^$]+)(?<!\s)\$", r"\$\1$", part)
-        # # Escape sequences of two or more $
-        # part = re.sub(r"([$]{2,})", lambda m: "\\" + "\\".join(m.group(1)), part)
 
         if self.inside_table:
             part = part.replace("|", r"\|")
@@ -662,7 +804,7 @@ class EvernoteHTMLToMarkdownConverter:
             return ''
 
         # Do not escape text from <pre>, <code> or <a> tags
-        if self.inside_pre: # or (node.parent and node.parent.name == "a"):
+        if self.inside_pre:
             return text
 
         # Split the text into parts, separating URLs and other text

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -27,6 +27,7 @@ import pickle
 import logging
 import sqlite3
 import mimetypes
+import hashlib
 from   bs4         import BeautifulSoup
 from   bs4.element import Tag
 from   typing      import Sequence, TypeVar, cast
@@ -108,12 +109,30 @@ for option, value, name, help in (
     ("check_emojis",       True,                "Warn if file name has emoji",   "Warn if files to be exported have emojis,\nwhich is unsupported in Dropbox and other programs."),
     ("check_tables",       True,                "Warn if table has merged cell", "Warn if tables have merged cells,\nwhich is unsupported in Obsidian Markdown by default."),
     ("check_format",       True,                "Warn of unsupported format",    "Warn if notes have formatting unsupported by Markdown,\nsuch as font size and color, underline, etc."),
-    ("pdf_view",           "default",           "Show PDFs as",                  "Choose how ALL PDF files will appear in the converted notes:\n - default: The same way as they appear in Evernote\n - title  : Show PDFs only as the title\n - preview: Preview of the first PDF page"),
+    ("pdf_view",           "hybrid",            "Show PDFs as",                  "Choose how ALL PDF files will appear in the converted notes:\n - default: The same way as they appear in Evernote\n - title  : Show PDFs only as the title\n - preview: Preview of the first PDF page\n - hybrid : Preview if single PDF, title if consecutive PDFs"),
     ("first_line_empty",   False,               "Make first note line empty",    "If True, add an empty line at the beginning of the note.\nThis is a cosmetic hack to avoid Obsidian showing code when you open a note in editing view."),
     ("remove_green_link",  False,               "Remove color of green links",   "For a while, Evernote made internal links (links to other notes) green.\nI recommend removing them and using a CSS snippet in Obsidian instead\nif you want all internal links to be green."),
     ("escape_brackets",    False,               "Replace [] with () in links",   "Square brackets [] are special characters in Markdown.\nThey can appear the text portion of your links, but might look a bit odd in Obsidian.\nSet this to True to replace them with parentheses ()."),
     ("links_with_folders", True,                "Include folder path in links",  "Obsidian can have multiple notes with the same name in different folders.\nSet this to True to include the folder path in links. This helps avoid confusion when multiple notes share the same name.\nSet this to False to use only the note title in links. This keeps links simpler but may cause conflicts if note names are duplicated."),
     ("notebooks",          None,                "",                              "Notebooks to export"),
+    ("global_resources",   True,                "Global _resources folder",      "If True, all attachments are stored in a single _resources folder at the vault root.\nIdentical files (same content) are deduplicated.\nThis makes it easier to reorganize notes without moving attachment folders.\nIf False, each notebook gets its own _resources subfolder."),
+    ("calendar_event_mode", "custom_callout",   "Calendar event rendering mode", "Choose how Evernote calendar events are rendered:\n - custom_callout: nested Obsidian custom callout\n - remove       : remove calendar event blocks\n - raw          : keep raw/default conversion (debug only)\nIf using custom callouts, enable the snippet in Obsidian:\nSettings → Appearance → CSS snippets."),
+    ("web_clip_mode",     "hybrid",             "Web clip rendering mode",        "Choose how web clips are rendered:\n - hybrid     : show iframe + archived clipped content in collapsed callout\n - iframe_only: only iframe (legacy behavior)\n - content_only: only archived clipped content in collapsed callout\nIf using custom web-clip callouts, enable the snippet in Obsidian:\nSettings → Appearance → CSS snippets."),
+    ("web_clip_iframe_width_px", 750,           "Web clip iframe width (px)",     "Fixed width for web-clip iframes (pixels)."),
+    ("web_clip_iframe_height_px", 600,          "Web clip iframe height (px)",    "Fixed height for web-clip iframes (pixels)."),
+    ("web_clip_callout_type", "custom-web-clip","Web clip callout type",         "Callout type name used for web clip callout blocks."),
+    ("web_clip_iframe_callout_title", "Web clip", "Iframe callout title",         "Callout title for the iframe (live site) callout. Expanded by default."),
+    ("web_clip_callout_title", "Archived web clip", "Archived callout title",     "Callout title for the archived content callout."),
+    ("web_clip_callout_collapsed", True,        "Collapse archived callout",      "If True, archived web clip callouts are collapsed by default."),
+    ("manage_custom_callout_css", True,         "Manage custom callout CSS",      "If True, converter writes/updates managed callout CSS snippet in your vault.\nAfter export, enable the snippet in Obsidian:\nSettings → Appearance → CSS snippets."),
+    ("custom_callout_css_path", ".obsidian/snippets/custom-callout.css", "Custom callout CSS path", "Path (relative to vault root) for managed custom callout CSS snippet.\nAfter export, enable this snippet in Obsidian:\nSettings → Appearance → CSS snippets."),
+    ("bold_date_log_to_headings", False,        "Bold date log to headings",     "If True, bold date entries like **29 June 2024** at the start of a line\nare converted to ## DD MMM YYYY headings."),
+    ("date_log_history_heading",  False,        "Auto-insert History heading",   "If True, a '# History' heading is inserted before the first date entry\nthat has no preceding section heading. Requires bold_date_log_to_headings."),
+    ("normalize_header_dates",    False,        "Normalize dates in headings",  "If True, any date in a heading (e.g. ## February 17, 2026) is normalized\nto DD MMM YYYY (e.g. ## 17 Feb 2026)."),
+    ("bold_as_heading",    False,               "Bold lines as headings",        "If True, in notes with no headings, standalone bold lines\n(e.g. <div><b>Section title</b></div>) are promoted to h2 headings."),
+    ("hr_as_h1",           False,               "Text + hr line as heading",     "If True, a text line immediately followed by a horizontal rule\nis converted to a level 1 heading (the hr is removed)."),
+    ("normalize_heading_levels", True,          "Normalize heading hierarchy",   "If True, heading level gaps are closed (e.g. h1 followed by h3\nbecomes h1 followed by h2). Headings with proper hierarchy are unaffected."),
+    ("suppress_attachment_rename_warnings", True, "Suppress attachment rename warnings", "If True, warnings for attachment renames due to auto-fixes (e.g., leading slash, duplicate, extension inference, query string) are suppressed. Only ambiguous/unfixable cases will warn."),
 ):
     default_cfg[option] = value
     if name:
@@ -125,12 +144,72 @@ for option, value, name, help in (
         }
         if option == "pdf_view":
             option_data[option]["type"]    = list
-            option_data[option]["options"] = ["default", "title", "preview"]
+            option_data[option]["options"] = ["default", "title", "preview", "hybrid"]
         elif option == "log_level":
             option_data[option]["type"]    = list
             option_data[option]["options"] = ["debug", "info", "warning", "error", "critical"]
+        elif option == "calendar_event_mode":
+            option_data[option]["type"]    = list
+            option_data[option]["options"] = ["custom_callout", "remove", "raw"]
+        elif option == "web_clip_mode":
+            option_data[option]["type"]    = list
+            option_data[option]["options"] = ["hybrid", "iframe_only", "content_only"]
 
 cfg     = Config(default=default_cfg) # Global var. used by most functions
+
+_option_groups = {
+    "database": "General",
+    "output_folder_md": "General",
+    "output_folder_html": "General",
+    "html_with_md_ext": "General",
+    "log_file": "General",
+    "log_level": "General",
+    "overwrite": "General",
+    "notebooks": "General",
+    "export_trash": "Export",
+    "export_empty_note": "Export",
+    "export_empty_file": "Export",
+    "max_path_len": "Export",
+    "max_attach_MB": "Export",
+    "check_emojis": "Validation",
+    "check_tables": "Validation",
+    "check_format": "Validation",
+    "suppress_attachment_rename_warnings": "Validation",
+    "remove_green_link": "Markdown",
+    "escape_brackets": "Markdown",
+    "links_with_folders": "Markdown",
+    "pdf_view": "Markdown",
+    "first_line_empty": "Markdown",
+    "bold_date_log_to_headings": "Headings",
+    "date_log_history_heading": "Headings",
+    "normalize_header_dates": "Headings",
+    "bold_as_heading": "Headings",
+    "hr_as_h1": "Headings",
+    "normalize_heading_levels": "Headings",
+    "calendar_event_mode": "Calendar",
+    "web_clip_mode": "Web clips",
+    "web_clip_iframe_width_px": "Web clips",
+    "web_clip_iframe_height_px": "Web clips",
+    "web_clip_callout_type": "Web clips",
+    "web_clip_iframe_callout_title": "Web clips",
+    "web_clip_callout_title": "Web clips",
+    "web_clip_callout_collapsed": "Web clips",
+    "manage_custom_callout_css": "Callout CSS",
+    "custom_callout_css_path": "Callout CSS",
+    "global_resources": "Resources",
+}
+
+_group_order = {
+    "General": 0,
+    "Export": 1,
+    "Validation": 2,
+    "Markdown": 3,
+    "Headings": 4,
+    "Calendar": 5,
+    "Web clips": 6,
+    "Callout CSS": 7,
+    "Resources": 8,
+}
 
 # Logging
 IMPORTANT = logging.CRITICAL +10
@@ -168,7 +247,14 @@ def restart_log(just_close=False):
         "critical": logging.CRITICAL
     }.get(cfg["log_level"], logging.WARNING)
 
-    # Create new file handler
+    # Clear the log file at the start of a new run
+    try:
+        with open(cfg["log_file"], "w", encoding="utf-8") as f:
+            pass
+    except Exception as e:
+        print(f"Could not clear log file: {e}")
+
+    # Create new file handler (append mode, but file is now empty)
     _log_handler = logging.FileHandler(cfg["log_file"], mode='a', encoding='utf-8')
     _log_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s', '%Y-%m-%d %H:%M:%S'))
     _logger.addHandler(_log_handler)
@@ -191,7 +277,16 @@ def cfg_menu():
     """Show current configuration and allow user to change it."""
 
     global cfg
-    values = [(o, f"{option_data[o]['menu_name']}: {cfg[o] if o in cfg else default_cfg[o]}") for o in option_data]
+    def _menu_label(opt):
+        group = _option_groups.get(opt, "Other")
+        value = cfg[opt] if opt in cfg else default_cfg[opt]
+        return f"[{group}] {option_data[opt]['name']}: {value}"
+
+    ordered_options = sorted(
+        option_data.keys(),
+        key=lambda o: (_group_order.get(_option_groups.get(o, "Other"), 999), option_data[o]["name"].lower()),
+    )
+    values = [(o, _menu_label(o)) for o in ordered_options]
     option = radiolist_dialog(
         title  = "Configuration",
         text   = "Select an item then <Change> to modify it, or <Back> to return:",
@@ -250,7 +345,7 @@ in the configuration, or sync Evernote data with:
     except Exception as e:
         log(logging.CRITICAL, f"Could not open database {db_path}")
         log(logging.CRITICAL, f"Exception: {e}")
-        return
+        return False
 
     return conn
 
@@ -277,7 +372,7 @@ def has_emoji(s):
     return bool(emoji_pattern.search(s))
 
 
-invalid_chars = r'[\\*"/<>:|?]'
+invalid_chars = r'[\\*"/<>:|?#^]'
 
 def is_invalid_obsidian_title(title):
     """ Return False if title is valid, otherwise return invalid chars. """
@@ -423,9 +518,87 @@ def sel_nb_menu():
     return True
 
 
+_invalid_char_replacements = str.maketrans({
+    '\\': '⧵',   # U+29F5  REVERSE SOLIDUS OPERATOR
+    '*':  '∗',   # U+2217  ASTERISK OPERATOR
+    '"':  '＂',  # U+FF02  FULLWIDTH QUOTATION MARK
+    '/':  '∕',   # U+2215  DIVISION SLASH
+    '<':  '＜',  # U+FF1C  FULLWIDTH LESS-THAN SIGN
+    '>':  '＞',  # U+FF1E  FULLWIDTH GREATER-THAN SIGN
+    ':':  '꞉',   # U+A789  MODIFIER LETTER COLON
+    '|':  '｜',  # U+FF5C  FULLWIDTH VERTICAL LINE
+    '?':  '？',  # U+FF1F  FULLWIDTH QUESTION MARK
+    '#':  '＃',  # U+FF03  FULLWIDTH NUMBER SIGN   (heading anchor in wikilinks)
+    '^':  '＾',  # U+FF3E  FULLWIDTH CIRCUMFLEX     (block ref in wikilinks)
+})
+
+_unicode_spaces = re.compile(r'[\u00A0\u2007\u202F\u2060\uFEFF]+')
+
 def safe_path(path):
-    # TO-DO: add in config. a custom character, translation map or regex?
-    return re.sub(invalid_chars, "_", path.strip())
+    path = _unicode_spaces.sub(' ', path.strip())
+    return path.translate(_invalid_char_replacements)
+
+
+def truncate_filename(filename, max_length=200):
+    """
+    Truncate filename to max_length while preserving extension.
+    If filename is too long, uses a hash to ensure uniqueness.
+    Windows path limit is 260 chars, so we use 200 as a safe default.
+    """
+    if len(filename) <= max_length:
+        return filename
+    
+    root, ext = os.path.splitext(filename)
+    if len(ext) > 10:  # Unreasonably long extension, might be wrong split
+        ext = ""
+    
+    # Use a short hash of the original filename to preserve uniqueness
+    file_hash = hashlib.md5(filename.encode()).hexdigest()[:8]
+    available_length = max_length - len(ext) - len(file_hash) - 1  # -1 for underscore
+    
+    if available_length < 10:
+        # Filename + extension is still too long, use just hash + extension
+        return f"{file_hash}{ext}"
+    
+    truncated_root = root[:available_length]
+    return f"{truncated_root}_{file_hash}{ext}"
+
+
+def truncate_full_path(full_path, max_path_length=None):
+    """
+    Ensure full path doesn't exceed Windows MAX_PATH (260 chars).
+    If too long, truncates the filename component intelligently.
+    Uses cfg["max_path_len"] if not provided.
+    Logs a warning if extension is dropped or replaced.
+    """
+    if max_path_length is None:
+        max_path_length = cfg.get("max_path_len", 255)
+    if len(full_path) <= max_path_length:
+        return full_path
+
+    # Split into directory and filename
+    directory = os.path.dirname(full_path)
+    filename = os.path.basename(full_path)
+
+    # Calculate how much space we have for the filename
+    available_for_filename = max_path_length - len(directory) - 1  # -1 for separator
+
+    if available_for_filename < 20:
+        # Directory path is too long, use just a hash as filename
+        file_hash = hashlib.md5(full_path.encode()).hexdigest()[:12]
+        root, ext = os.path.splitext(filename)
+        if len(ext) > 10:
+            log(logging.INFO, f"Extension too long, replaced with .bin for file: {filename}")
+            ext = ".bin"  # fallback extension
+        return posix_join(directory, f"{file_hash}{ext}")
+
+    # Truncate the filename to fit
+    # Check if extension will be dropped in truncate_filename
+    root, ext = os.path.splitext(filename)
+    if len(ext) > 10:
+        log(logging.INFO, f"Extension too long, dropped for file: {filename}")
+    truncated_fn = truncate_filename(filename, available_for_filename - 10)  # -10 safety margin
+    return posix_join(directory, truncated_fn)
 
 
 def safe_join(*paths):
@@ -448,7 +621,7 @@ def list_db():
 
     log(IMPORTANT, "Listing notes in selected notebooks.")
 
-    for notebook in sorted(notebooks, key=lambda x: f"{x['stack' or '']}{x['name']}".lower() ):
+    for notebook in sorted(notebooks, key=lambda x: f"{x.get('stack') or ''}{x.get('name') or ''}".lower()):
         # Process only selected notebooks
         if cfg["notebooks"] and notebook["guid"] not in cfg["notebooks"]:
             continue
@@ -505,13 +678,17 @@ def scan_db():
     max_path_len  = cfg["max_path_len"]
     max_attach_MB = cfg["max_attach_MB"] * 1024 * 1024
 
-    def issue(msg):
+    def issue(msg, warn_type=None):
         nonlocal total_issues
+        # If suppress_attachment_rename_warnings is True, suppress certain auto-fix warnings
+        suppress = cfg.get("suppress_attachment_rename_warnings", False)
+        if suppress and warn_type in {"auto-rename", "leading-slash", "duplicate", "extension-infer", "query-string"}:
+            return 0
         log(IMPORTANT, f" - {msg}")
         total_issues += 1
         return 1
 
-    for notebook in sorted(notebooks, key=lambda x: f"{x['stack' or '']}{x['name']}".lower() ):
+    for notebook in sorted(notebooks, key=lambda x: f"{x.get('stack') or ''}{x.get('name') or ''}".lower()):
         # Process only selected notebooks
         if cfg["notebooks"] and notebook["guid"] not in cfg["notebooks"]:
             continue
@@ -568,7 +745,8 @@ def scan_db():
 
             # Check for invalid names in note titles
             if (chars := is_invalid_obsidian_title(note.title)):
-                note_has_issue = issue(f"[{note.title}] Invalid chars [{chars}] in note title")
+                if not cfg.get("suppress_fixable_warnings", False):
+                    note_has_issue = issue(f"[{note.title}] Invalid chars [{chars}] in note title")
             # Don't check if title ends with period, since file will end with ".md"
             if note.title.startswith("."):
                 note_has_issue = issue(f"[{note.title}] Note title starting with a dot will be hidden")
@@ -632,7 +810,8 @@ def scan_db():
                         if test in filtered_note_content:
                             issues.append(issue_name)
                 if issues:
-                    note_has_issue = issue(f"[{note.title}] Unsupported formatting: {', '.join(issues)}")
+                    if not cfg.get("suppress_fixable_warnings", False):
+                        note_has_issue = issue(f"[{note.title}] Unsupported formatting: {', '.join(issues)}")
 
             # Attachment tests
             for resource in note.resources or []:
@@ -640,20 +819,28 @@ def scan_db():
                 if fn:
                     fn = fn.strip()
                     attachments.append(fn)
-                    # Save full path of attachments for later tests
-                    # TO-DO: create single function to create this path; let user set another value in cfg instead of "_resources"
-                    full_path = posix_join(notebook_path, "_resources", safe_path(fn))
+                    fn_safe = safe_path(fn)
+                    fn_safe = truncate_filename(fn_safe)
+                    if cfg.get("global_resources", True):
+                        full_path = posix_join(self.output_folder, "_resources", fn_safe)
+                    else:
+                        full_path = posix_join(notebook_path, "_resources", fn_safe)
+                    # Apply full path truncation to match what export will do
+                    full_path = truncate_full_path(full_path)
                     full_paths.append(full_path)
 
                     # Check max. path length
                     if max_path_len and len(full_path) > max_path_len:
-                        note_has_issue = issue(f"[{note.title}] Exported attachment path will have {len(full_path)} characters: {full_path}")
+                        if not cfg.get("suppress_fixable_warnings", False):
+                            note_has_issue = issue(f"[{note.title}] Exported attachment path will have {len(full_path)} characters: {full_path}")
 
                     # Check for invalid names in attachments
                     if (chars := is_invalid_obsidian_title(fn)):
-                        note_has_issue = issue(f"[{note.title}] Invalid chars [{chars}] in attachment name: {fn}")
+                        if not cfg.get("suppress_fixable_warnings", False):
+                            note_has_issue = issue(f"[{note.title}] Invalid chars [{chars}] in attachment name: {fn}")
                     if fn.endswith("."):
-                        note_has_issue = issue(f"[{note.title}] Invalid chars in attachment name: {fn}")
+                        if not cfg.get("suppress_fixable_warnings", False):
+                            note_has_issue = issue(f"[{note.title}] Invalid chars in attachment name: {fn}")
 
                     # Check for 0 bytes attachments
                     # assert resource.data.size == len(resource.data.body)
@@ -729,7 +916,7 @@ class Exporter:
         self.note_ext      = note_ext
 
 
-    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options):
+    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options, deleted_guid_to_title):
         raise NotImplementedError("Subclasses must implement this method")
 
 
@@ -752,7 +939,7 @@ class Exporter:
                 log(logging.DEBUG, f"Tasks table not found in the database. Skipping task processing for note {note_guid}.")
                 return tasks
             except Exception as e:
-                log(logging.WARN, f"Error executing query for tasks for note {note_guid}: {e}")
+                log(logging.WARNING, f"Error executing query for tasks for note {note_guid}: {e}")
                 return tasks
             for task_guid, raw_task in cursor:
                 try:
@@ -802,10 +989,12 @@ class Exporter:
         guid_to_path_abs = {} # Keep track of Evernote internal links to notes and files (absolute path, used internally during conversion)
         path_to_guid     = {} # Keep track of Evernote internal links to notes and files
         hash_to_paths    = {} # Keep track of Evernote hashes to attachments
+        deleted_guid_to_title = {} # Best-effort fallback targets for links to deleted notes
         filenames_set    = set() # Keep track of filenames in lowercase
+        content_hash_to_global_path = {} # For global_resources dedup: content hash -> path relative to output root
         notebook_data    = []
         notebooks        = get_notebooks_from_db(conn)
-        sorted_notebooks = sorted(notebooks, key=lambda x: f"{x['stack' or '']}{x['name']}".lower() )
+        sorted_notebooks = sorted(notebooks, key=lambda x: f"{x.get('stack') or ''}{x.get('name') or ''}".lower())
 
         for notebook in sorted_notebooks:
             # If we process only selected notebooks, processing time can be 
@@ -828,6 +1017,13 @@ class Exporter:
 
             # Get notes in the current notebook
             for row_note in get_notes_from_notebook(conn, notebook["guid"]):
+                is_active, raw_note = row_note
+                if not is_active:
+                    try:
+                        deleted_note = pickle.loads(lzma.decompress(raw_note))
+                        deleted_guid_to_title[deleted_note.guid] = deleted_note.title or ""
+                    except Exception as e:
+                        log(logging.DEBUG, f"Could not parse deleted note metadata for fallback links: {e}")
                 note, note_content, tasks = get_note_notecontent(row_note)
                 if not note: # skip deleted or empty notes, according to config.
                     continue
@@ -841,7 +1037,11 @@ class Exporter:
                 note_path_abs = posix_join(notebook_path_abs, safe_name)
                 filenames_set.add(note_path_rel.lower())
                 path_to_guid    [note_path_rel] = note.guid
-                guid_to_path_rel[note.guid]     = note_path_rel
+                # Strip .md extension for internal note links
+                if note_path_rel.lower().endswith('.md'):
+                    guid_to_path_rel[note.guid] = note_path_rel[:-3]
+                else:
+                    guid_to_path_rel[note.guid] = note_path_rel
                 guid_to_path_abs[note.guid]     = note_path_abs
 
                 # Create unique RELATIVE attachment path from notebook attachment name
@@ -854,46 +1054,61 @@ class Exporter:
                     # and there can be issues in Obsidian displaying files with wrong extension.
                     # So, be sure attachment has a file name with correct extension.
                     fn        = resource.attributes.fileName or "unnamed"
-                    mime_ext  = mimetypes.guess_extension(resource.mime, strict=False) # "image/png" -> ".png"
+                    mime_ext  = mimetypes.guess_extension(resource.mime, strict=False) or ""  # "image/png" -> ".png"
                     root, ext = os.path.splitext(fn)
                     if root.strip() == "":
                         root = "unnamed"
                     if ext.strip() == "" and resource.mime != "application/octet-stream":
                         ext = mime_ext
                     fn = safe_path(f"{root}{ext}")
+                    fn = truncate_filename(fn)  # Truncate to avoid Windows path length limits
 
-                    # TO-DO:
-                    # - Allow user to select folder for attachments (one per notebook / one per note ?)
-                    #   - In case of HTML files, use "correct" format ([html file without ext]_files) ?
-                    # - We're also not checking if there are links to each/all attachment in the note content. But should we?
                     attachment_folder_rel = "_resources"
-                    # Create a unique full relative path for the attachment
-                    full_attachment_path_rel = posix_join(notebook_path_rel, attachment_folder_rel, fn)
-                    unique_full_path_rel     = get_unique_filename(full_attachment_path_rel, filenames_set)
-                    attachment_path_rel      = to_posix(os.path.relpath(unique_full_path_rel, notebook_path_rel)) # Path relative to note
-                    attachment_path_abs      = posix_join(self.output_folder, unique_full_path_rel)
+                    content_hash = int.from_bytes(resource.data.bodyHash)
+
+                    if cfg.get("global_resources", True):
+                        # Global mode: single _resources at vault root with dedup
+                        if content_hash in content_hash_to_global_path:
+                            # Same content already stored — reuse the global path
+                            unique_full_path_rel = content_hash_to_global_path[content_hash]
+                        else:
+                            # New content — compute path, ensure filename uniqueness
+                            full_attachment_path_rel = posix_join(attachment_folder_rel, fn)
+                            unique_full_path_rel = get_unique_filename(full_attachment_path_rel, filenames_set)
+                            filenames_set.add(unique_full_path_rel.lower())
+                            content_hash_to_global_path[content_hash] = unique_full_path_rel
+                    else:
+                        # Per-notebook mode: _resources inside each notebook folder
+                        full_attachment_path_rel = posix_join(notebook_path_rel, attachment_folder_rel, fn)
+                        unique_full_path_rel = get_unique_filename(full_attachment_path_rel, filenames_set)
+                        filenames_set.add(unique_full_path_rel.lower())
+
+                    attachment_path_rel = to_posix(os.path.relpath(unique_full_path_rel, notebook_path_rel)) # Path relative to note
+                    attachment_path_abs = posix_join(self.output_folder, unique_full_path_rel)
 
                     fn = os.path.split(attachment_path_abs)[-1]
                     if resource.attributes.fileName and fn != resource.attributes.fileName:
-                        log(logging.WARNING, f'  - Attachment renamed from "{resource.attributes.fileName}" to "{attachment_path_abs}" in {note_path_abs}')
+                        suppress = cfg.get("suppress_attachment_rename_warnings", False)
+                        if not suppress:
+                            log(logging.INFO, f'  - Attachment renamed from "{resource.attributes.fileName}" to "{attachment_path_abs}" in {note_path_abs}')
 
-                    # Obsidian seems to support relative paths in HTML tags now. But it previously didn't. See:
-                    # https://forum.obsidian.md/t/support-img-and-video-tag-with-src-relative-path-format/18647/47
-                    # if self.format == "HTML" and self.note_ext == ".md":
-                    #     # Use RELATIVE paths in attachment_path if converting to Markdown or to HTML files
-                    #     # Use ABSOLUTE paths in attachment_path if converting to .md files in HTML format
-                    #     attachment_path_rel = attachment_path_abs
-                    filenames_set.add(unique_full_path_rel.lower())
                     path_to_guid[attachment_path_rel] = resource.guid
                     guid_to_path_rel[resource.guid]   = attachment_path_rel
                     guid_to_path_abs[resource.guid]   = attachment_path_abs
-                    hash = int.from_bytes(resource.data.bodyHash) # Better int than .hex().zfill(32) ?
-                    # Store all paths for a given hash, keyed by the note's GUID
-                    if hash not in hash_to_paths:
-                        hash_to_paths[hash] = {}
-                    hash_to_paths[hash][note.guid] = attachment_path_rel
+                    if content_hash not in hash_to_paths:
+                        hash_to_paths[content_hash] = {}
+                    hash_to_paths[content_hash][note.guid] = attachment_path_rel
+                    # Some web clips use resource GUID in en-media hash instead of bodyHash.
+                    try:
+                        guid_hash = int(resource.guid.replace("-", ""), 16)
+                        if guid_hash not in hash_to_paths:
+                            hash_to_paths[guid_hash] = {}
+                        hash_to_paths[guid_hash][note.guid] = attachment_path_rel
+                    except ValueError:
+                        pass
 
         # 2nd pass: export notes
+        saved_attachments = set()  # Track saved attachment paths for dedup in global mode
         log(IMPORTANT, f"Exporting from {cfg['database']} to {self.format} into {self.output_folder}")
 
         for nb_data in notebook_data:
@@ -917,9 +1132,12 @@ class Exporter:
                     continue
 
                 note_path_abs = guid_to_path_abs[note.guid]
-
+                # Ensure full path doesn't exceed Windows MAX_PATH (260 chars)
+                note_path_abs = truncate_full_path(note_path_abs)
+                if len(note_path_abs) > cfg.get("max_path_len", 255):
+                    log(logging.ERROR, f"  ERROR: Note path still too long after truncation: {note_path_abs}")
                 if not cfg["overwrite"] and os.path.exists(note_path_abs):
-                    log(logging.WARNING, f"  - Skipping, already exists: {note_path_abs}")
+                    log(logging.INFO, f"  - Skipping, already exists: {note_path_abs}")
                     save_note = False
                 else:
                     log(logging.INFO, f"  - {note_path_abs}")
@@ -936,13 +1154,13 @@ class Exporter:
                     group_id  = task["taskGroupNoteLevelID"]
                     label     = task["label"]
                     if "dueDate" in task:
-                          due = epoch_to_local_time(task["dueDate"] // 1000, task["timeZone"])
+                          due = epoch_to_local_time(task["dueDate"] // 1000, task.get("timeZone", "UTC"))
                           due = f" 📅 {due}"
                     else: due = ""
                     reminders = ""
                     for reminder in task["reminders"]:
                         bell = "🔔" if reminder.get("status") == "active" else "🔕"
-                        rmd_due = epoch_to_local_time(reminder["reminderDate"] // 1000, reminder["timeZone"])
+                        rmd_due = epoch_to_local_time(reminder["reminderDate"] // 1000, reminder.get("timeZone", "UTC"))
                         reminders += f" {bell} {rmd_due}"
                     flag      = "🚩" if task.get("flag") else ""
                     completed = "x" if task.get("status") == "completed" else " "
@@ -952,22 +1170,52 @@ class Exporter:
 
                 # Process attachments
                 for resource in note.resources or []:
+
                     if not cfg["export_empty_file"] and resource.data.size == 0:
                         continue
 
-                    attachment_path_abs = guid_to_path_abs[resource.guid]
+                    # Always enforce full path truncation for attachments
 
-                    # Save attachment file
-                    os.makedirs(os.path.dirname(attachment_path_abs), exist_ok=True)
-                    if not cfg["overwrite"] and os.path.exists(attachment_path_abs):
-                        log(logging.WARNING, f"    - Skipping, already exists: {attachment_path_abs}")
+                    orig_attachment_path_abs = guid_to_path_abs[resource.guid]
+                    # Compute the full absolute path from the filesystem root
+                    workspace_root = os.path.abspath(os.getcwd())
+                    # If output_folder is relative, join with workspace root
+                    if not os.path.isabs(orig_attachment_path_abs):
+                        abs_attachment_path = os.path.abspath(os.path.join(workspace_root, orig_attachment_path_abs))
                     else:
+                        abs_attachment_path = orig_attachment_path_abs
+
+                    # Truncate based on the full absolute path
+                    truncated_abs_attachment_path = truncate_full_path(abs_attachment_path)
+                    # If still too long, fallback to hash-only filename
+                    if len(truncated_abs_attachment_path) > cfg.get("max_path_len", 255):
+                        directory = os.path.dirname(truncated_abs_attachment_path)
+                        ext = os.path.splitext(truncated_abs_attachment_path)[1]
+                        file_hash = hashlib.md5(truncated_abs_attachment_path.encode()).hexdigest()[:12]
+                        truncated_abs_attachment_path = posix_join(directory, f"{file_hash}{ext}")
+                        log(logging.WARNING, f"  WARNING: Attachment path fallback to hash-only: {truncated_abs_attachment_path}")
+
+                    # Update the guid_to_path_abs so Markdown references use the truncated path (relative to output_folder)
+                    # Compute the path relative to the output folder for Markdown
+                    rel_truncated_path = os.path.relpath(truncated_abs_attachment_path, os.path.abspath(self.output_folder))
+                    rel_truncated_path = to_posix(rel_truncated_path)
+                    guid_to_path_abs[resource.guid] = truncated_abs_attachment_path
+                    guid_to_path_rel[resource.guid] = rel_truncated_path
+
+                    # Save attachment file (skip if already saved via dedup)
+                    if truncated_abs_attachment_path in saved_attachments:
+                        log(logging.DEBUG, f"    - Dedup skip: {truncated_abs_attachment_path}")
+                    elif not cfg["overwrite"] and os.path.exists(truncated_abs_attachment_path):
+                        log(logging.INFO, f"    - Skipping, already exists: {truncated_abs_attachment_path}")
+                    else:
+                        os.makedirs(os.path.dirname(truncated_abs_attachment_path), exist_ok=True)
                         try:
-                            with open(attachment_path_abs, "wb") as fh:
+                            with open(truncated_abs_attachment_path, "wb") as fh:
                                 fh.write(resource.data.body)
-                            log(logging.INFO, f"    - ({len(resource.data.body):,} bytes) {attachment_path_abs}")
+                            log(logging.INFO, f"    - ({len(resource.data.body):,} bytes) {truncated_abs_attachment_path}")
                         except Exception as e:
-                            errors.append( log(logging.ERROR, f"  Error saving {attachment_path_abs}: **{e}**") )
+                            errors.append( log(logging.ERROR, f"  Error saving {truncated_abs_attachment_path}: **{e}**") )
+                    saved_attachments.add(truncated_abs_attachment_path)
 
                 if save_note:
                     # Prepare note properties
@@ -1007,23 +1255,28 @@ class Exporter:
 
                     # Convert note body to HTML or Markdown
                     converted_content, conversion_issues = self.convert(
-                        note, note_content, guid_to_path_rel, path_to_guid, hash_to_paths, task_groups, cfg)
+                        note, note_content, guid_to_path_rel, path_to_guid, hash_to_paths, task_groups, cfg, deleted_guid_to_title)
 
                     if conversion_issues:
-                        log(logging.WARNING, f'Issues converting "{note.title}" ({note_path_abs}):')
-                        for issue in conversion_issues:
-                            log(logging.WARNING, f"  - {issue}")
+                        max_level = max(level for level, _ in conversion_issues)
+                        log(max_level, f'Issues converting "{note.title}" ({note_path_abs}):')
+                        for level, issue in conversion_issues:
+                            log(level, f"  - {issue}")
 
                     # Save note
+                    # Ensure full path doesn't exceed Windows MAX_PATH (260 chars)
+                    save_path_abs = note_path_abs  # Already truncated above
+                    if len(save_path_abs) > cfg.get("max_path_len", 255):
+                        log(logging.ERROR, f"  ERROR: Note save path still too long after truncation: {save_path_abs}")
                     try:
-                        with open(note_path_abs, "w", encoding="utf-8") as fh:
+                        with open(save_path_abs, "w", encoding="utf-8") as fh:
                             if self.note_ext == ".md":
                                 fh.write(md_properties)
                             if cfg["first_line_empty"]:
                                 converted_content = "\n" + converted_content
                             fh.write(converted_content)
                     except Exception as e:
-                        errors.append( log(logging.ERROR, f"  Error saving {note_path_abs}: **{e}**") )
+                        errors.append( log(logging.ERROR, f"  Error saving {save_path_abs}: **{e}**") )
 
         if errors:
             log(logging.ERROR, f"{len(errors):,} error(s) found.")
@@ -1044,8 +1297,12 @@ class Exporter_HTML(Exporter):
             note_ext      = ".md" if cfg["html_with_md_ext"] else ".html",
         )
 
+    def export(self):
+        restart_log()  # Clear log at the start of HTML export
+        return super().export()
 
-    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options):
+
+    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options, deleted_guid_to_title):
 
         errors = []
 
@@ -1094,13 +1351,17 @@ class Exporter_HTML(Exporter):
             # <guid>#<guid> -> Links to items inside notes?
             guid = guid.split("#")[0]
             if not (path := guid_to_path.get(guid)):
-                path  = regex_match[0]
-                log(logging.ERROR, f"    - [ERROR] Path to GUID not found: {guid} ({path})")
+                if deleted_guid_to_title.get(guid):
+                    path = deleted_guid_to_title[guid]
+                    log(logging.INFO, f"    - Link fallback for deleted GUID: {guid} ({path})")
+                else:
+                    path  = regex_match[0]
+                    log(logging.ERROR, f"    - [ERROR] Path to GUID not found: {guid} ({path})")
             return f'"{path}"'
 
-        content = re.sub(r'<en-media ([^>]+)\s*/>', subs_en_media, content)
-        content = re.sub(r'"(?:evernote:///view/[^/]+/[^/]+/(.+?)/.+?|https://share.evernote.com/note/(.+?))"', subs_href, content)
-        return content, errors
+        processed_content = re.sub(r'<en-media ([^>]+)\s*/>', subs_en_media, content)
+        processed_content = re.sub(r'"(?:evernote:///view/[^/]+/[^/]+/(.+?)/.+?|https://share.evernote.com/note/(.+?))"', subs_href, processed_content)
+        return processed_content, errors
 
 
 class Exporter_MD(Exporter):
@@ -1113,26 +1374,715 @@ class Exporter_MD(Exporter):
         )
         self.converter = EvernoteHTMLToMarkdownConverter(use_html=cfg["html_with_md_ext"])
 
+    def export(self):
+        restart_log()  # Clear log at the start of Markdown export
+        self._ensure_custom_callout_css(cfg)
+        return super().export()
 
-    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options):
-        # Create a simple {hash: path} dictionary for the current note for the converter
+    @staticmethod
+    def _resolve_calendar_event_mode(options):
+        """Resolve calendar event rendering mode with backward-compatible fallback."""
+        mode = options.get("calendar_event_mode")
+        if mode in {"custom_callout", "remove", "raw"}:
+            return mode
+        # Backward compatibility for legacy boolean option
+        legacy = options.get("calendar_as_custom_callout")
+        if isinstance(legacy, bool):
+            return "custom_callout" if legacy else "remove"
+        return "custom_callout"
+
+    @staticmethod
+    def _web_clip_iframe_html(options, source_url):
+        """Build iframe HTML wrapped in an expanded-by-default collapsible callout."""
+        width = options.get("web_clip_iframe_width_px", 750)
+        height = options.get("web_clip_iframe_height_px", 600)
+        try:
+            width = max(100, int(width))
+        except (TypeError, ValueError):
+            width = 750
+        try:
+            height = max(100, int(height))
+        except (TypeError, ValueError):
+            height = 600
+        iframe = f'<iframe src="{source_url}" height="{height}px" width="{width}px"></iframe>'
+        callout_type = options.get("web_clip_callout_type", "custom-web-clip").strip() or "custom-web-clip"
+        title = options.get("web_clip_iframe_callout_title", "Web clip").strip() or "Web clip"
+        return f"> [!{callout_type}]+ {title}\n><br> {iframe}"
+
+    def _ensure_custom_callout_css(self, options):
+        """
+        Ensure custom callout CSS exists for enabled converter-generated callouts.
+        Keeps changes inside a managed block to avoid clobbering user CSS.
+        """
+        if not options.get("manage_custom_callout_css", True):
+            return
+
+        mode = self._resolve_web_clip_mode(options)
+        needs_calendar = self._resolve_calendar_event_mode(options) == "custom_callout"
+        needs_webclip = mode in {"hybrid", "content_only"}
+        css_rel_path = options.get("custom_callout_css_path", ".obsidian/snippets/custom-callout.css")
+        css_rel_path = to_posix(css_rel_path).lstrip("/")
+        css_path = os.path.join(self.output_folder, css_rel_path)
+        snippet_dir = os.path.dirname(css_path)
+
+        start_marker = "/* evernote2obsidian-managed-start */"
+        end_marker = "/* evernote2obsidian-managed-end */"
+
+        existing = ""
+        if os.path.exists(css_path):
+            with open(css_path, "r", encoding="utf-8") as f:
+                existing = f.read()
+
+        pattern = re.compile(
+            re.escape(start_marker) + r".*?" + re.escape(end_marker) + r"\n?",
+            flags=re.DOTALL,
+        )
+        cleaned = re.sub(pattern, "", existing).rstrip()
+        if not (needs_calendar or needs_webclip):
+            # No feature needs the managed CSS; remove managed block and clean up.
+            if cleaned.strip():
+                if cleaned != existing:
+                    with open(css_path, "w", encoding="utf-8") as f:
+                        f.write(cleaned + "\n")
+            elif os.path.exists(css_path):
+                os.remove(css_path)
+            return
+
+        os.makedirs(snippet_dir, exist_ok=True)
+        blocks = []
+        if needs_calendar:
+            blocks.append(
+                '.callout[data-callout="custom-calendar-event"] {\n'
+                "    --callout-color: 120, 82, 238;\n"
+                "    --callout-icon: calendar-days;\n"
+                "}"
+            )
+        if needs_webclip:
+            web_clip_type = options.get("web_clip_callout_type", "custom-web-clip").strip() or "custom-web-clip"
+            blocks.append(
+                f'.callout[data-callout="{web_clip_type}"]' + " {\n"
+                "    --callout-color: 59, 162, 186;\n"
+                "    --callout-icon: globe;\n"
+                "}"
+            )
+        managed_block = (
+            f"{start_marker}\n"
+            + "\n\n".join(blocks)
+            + f"\n{end_marker}\n"
+        )
+        # Remove legacy unmanaged definitions for the same callouts to avoid duplicates.
+        selectors = ["custom-calendar-event"]
+        selectors.append(options.get("web_clip_callout_type", "custom-web-clip").strip() or "custom-web-clip")
+        for selector in selectors:
+            cleaned = re.sub(
+                r'\.callout\[data-callout="' + re.escape(selector) + r'"\]\s*\{[^}]*\}\s*',
+                "",
+                cleaned,
+                flags=re.DOTALL,
+            ).rstrip()
+        final_css = (cleaned + "\n\n" + managed_block).lstrip("\n") if cleaned else managed_block
+
+        with open(css_path, "w", encoding="utf-8") as f:
+            f.write(final_css)
+
+    @staticmethod
+    def _css_unescape(s):
+        """Unescape a CSS string value (remove backslash escaping)."""
+        result = []
+        i = 0
+        while i < len(s):
+            if s[i] == '\\' and i + 1 < len(s):
+                result.append(s[i+1])
+                i += 2
+            else:
+                result.append(s[i])
+                i += 1
+        return ''.join(result)
+
+    @staticmethod
+    def _format_time(dt):
+        """Format datetime time component (e.g., '10:00 AM' or '6:00 PM')."""
+        time_str = dt.strftime('%I:%M %p')
+        if time_str[0] == '0':
+            time_str = time_str[1:]
+        return time_str
+
+    def _format_calendar_datetime(self, start_ms, end_ms, is_all_day=False):
+        """Format start/end epoch-ms timestamps into a readable date & time string."""
+        local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+        start_dt = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).astimezone(local_tz)
+        end_dt   = datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc).astimezone(local_tz)
+
+        if is_all_day:
+            if start_dt.date() == end_dt.date() or (end_dt - start_dt).days <= 1:
+                return start_dt.strftime('%a, %b %d, %Y') + ' (All day)'
+            return f"{start_dt.strftime('%a, %b %d, %Y')} – {end_dt.strftime('%a, %b %d, %Y')} (All day)"
+
+        start_date_str = start_dt.strftime('%a, %b %d, %Y')
+        end_date_str   = end_dt.strftime('%a, %b %d, %Y')
+        start_time = self._format_time(start_dt)
+        end_time   = self._format_time(end_dt)
+
+        if start_dt.date() == end_dt.date():
+            return f"{start_date_str}, {start_time} – {end_time}"
+        return f"{start_date_str}, {start_time} – {end_date_str}, {end_time}"
+
+    @staticmethod
+    def _html_description_to_text(html_desc):
+        """Convert an HTML event description to plain text with paragraph breaks."""
+        soup = BeautifulSoup(html_desc, 'html.parser')
+        for sup in soup.find_all('sup'):
+            sup.decompose()
+        for p in soup.find_all('p'):
+            if not p.get_text(strip=True):
+                p.replace_with('\n')
+            else:
+                p.insert_after('\n\n')
+        for br in soup.find_all('br'):
+            br.replace_with('\n')
+        for li in soup.find_all('li'):
+            li.insert(0, '- ')
+            li.insert_after('\n')
+        text = soup.get_text().strip()
+        text = re.sub(r'\n{4,}', '\n\n\n', text)
+        return text
+
+    def _format_calendar_callout(self, event_data):
+        """Build a nested Obsidian callout string from structured calendar event data."""
+        summary    = event_data.get('summary', 'Calendar Event')
+        start_ms   = event_data.get('start')
+        end_ms     = event_data.get('end')
+        description = event_data.get('description', '')
+        links      = event_data.get('links', [])
+        is_all_day = event_data.get('isAllDay', False)
+
+        event_url = ''
+        for link in links:
+            if link.get('type') == 'WEB':
+                event_url = link.get('uri', '')
+                break
+
+        date_time_str = ''
+        if start_ms and end_ms:
+            date_time_str = self._format_calendar_datetime(start_ms, end_ms, is_all_day)
+
+        lines = [f'> [!custom-calendar-event] {summary}']
+
+        dt_parts = []
+        if date_time_str:
+            dt_parts.append(f'**Date & Time:** {date_time_str}')
+        if event_url:
+            dt_parts.append(f'[Event link]({event_url})')
+        if dt_parts:
+            lines.append('> ' + ' | '.join(dt_parts) + ' ')
+
+        if description:
+            if '<p>' in description.lower() or '<br' in description.lower():
+                description_text = self._html_description_to_text(description)
+            else:
+                description_text = description
+
+            lines.append('> > [!example]- Click to show event description')
+            for desc_line in description_text.split('\n'):
+                stripped = desc_line.rstrip()
+                if stripped:
+                    lines.append(f'> > {stripped}')
+                else:
+                    lines.append('> >')
+
+        return '\n'.join(lines) + '\n'
+
+    def _extract_and_replace_calendar_events(self, html_content):
+        """Find --en-calendarBlock divs in HTML, replace with placeholders, return event data."""
+        soup = BeautifulSoup(html_content, 'html.parser')
+        events = []
+
+        for div in soup.find_all('div', style=True):
+            style = div.get('style', '')
+            if '--en-calendarBlock:true' not in style:
+                continue
+
+            idx = style.find('--en-calendarEvent:')
+            if idx < 0:
+                continue
+
+            rest = style[idx + len('--en-calendarEvent:'):]
+            q1 = rest.find('"')
+            if q1 < 0:
+                continue
+
+            pos = q1 + 1
+            while pos < len(rest):
+                if rest[pos] == '"' and rest[pos - 1] != '\\':
+                    break
+                pos += 1
+            css_str = rest[q1 + 1:pos]
+            json_str = self._css_unescape(css_str)
+
+            try:
+                event_data = json.loads(json_str)
+            except json.JSONDecodeError:
+                continue
+
+            events.append(event_data)
+            placeholder_tag = soup.new_tag('div')
+            placeholder_tag.string = f'EVERNOTE_CALENDAR_PLACEHOLDER_{len(events) - 1}'
+            div.replace_with(placeholder_tag)
+
+        return str(soup), events
+
+    @staticmethod
+    def _remove_calendar_events(html_content):
+        """Remove Evernote calendar block divs from HTML content."""
+        soup = BeautifulSoup(html_content, 'html.parser')
+        for div in list(soup.find_all('div', style=True)):
+            style = div.get('style', '')
+            if '--en-calendarBlock:true' in style:
+                div.decompose()
+        return str(soup)
+
+    @staticmethod
+    def _is_web_clip(note):
+        """Check if a note is a pure Evernote web clip with no user-added content."""
+        source_url = getattr(note.attributes, 'sourceURL', '') or ''
+        if not source_url:
+            return False
+        if '--en-clipped-content' not in note.content:
+            return False
+        soup = BeautifulSoup(note.content, 'html.parser')
+        en_note = soup.find('en-note')
+        if not en_note:
+            return True
+        for child in en_note.children:
+            if not hasattr(child, 'get'):
+                if str(child).strip():
+                    return False
+                continue
+            style = child.get('style', '')
+            if '--en-clipped-content' in style or '--en-clipped-source' in style:
+                continue
+            if child.get_text(strip=True):
+                return False
+        return True
+
+    @staticmethod
+    def _replace_clipped_content_with_iframe(content, source_url):
+        """Replace --en-clipped-content divs with an iframe, preserving other content."""
+        placeholder = "EVERNOTE_WEBCLIP_IFRAME_PLACEHOLDER"
+        soup = BeautifulSoup(content, 'html.parser')
+        for div in list(soup.find_all('div')):
+            style = div.get('style', '')
+            if '--en-clipped-content' in style:
+                wrapper = soup.new_tag('div')
+                wrapper.string = placeholder
+                div.replace_with(wrapper)
+        return str(soup), placeholder
+
+    @staticmethod
+    def _resolve_web_clip_mode(options):
+        """Resolve configured web clip mode with backward-compatible fallback."""
+        mode = options.get("web_clip_mode")
+        if mode in {"hybrid", "iframe_only", "content_only"}:
+            return mode
+        legacy_iframe = options.get("web_clip_as_iframe")
+        if isinstance(legacy_iframe, bool):
+            return "iframe_only" if legacy_iframe else "hybrid"
+        return "hybrid"
+
+    @staticmethod
+    def _split_web_clip_content(content):
+        """Split note HTML into (user_content, clipped_content) fragments."""
+        soup = BeautifulSoup(f"<en-note>{content}</en-note>", 'html.parser')
+        en_note = soup.find('en-note')
+        if not en_note:
+            return content, ""
+        clipped_parts = []
+        for child in list(en_note.children):
+            if not hasattr(child, 'get'):
+                continue
+            style = child.get('style', '')
+            if '--en-clipped-content' in style or '--en-clipped-source' in style:
+                clipped_parts.append(str(child))
+                child.extract()
+        user_content = ''.join(str(child) for child in en_note.children).strip()
+        clipped_content = ''.join(clipped_parts).strip()
+        return user_content, clipped_content
+
+    @staticmethod
+    def _wrap_web_clip_callout(markdown_content, options):
+        """Wrap markdown content in a configurable web-clip callout."""
+        if not markdown_content.strip():
+            return ""
+        callout_type = options.get("web_clip_callout_type", "custom-web-clip").strip() or "custom-web-clip"
+        title = options.get("web_clip_callout_title", "Archived web clip").strip() or "Archived web clip"
+        collapsed = "-" if options.get("web_clip_callout_collapsed", True) else ""
+        lines = [f"> [!{callout_type}]{collapsed} {title}"]
+        for line in markdown_content.split('\n'):
+            lines.append(f"> {line}" if line else ">")
+        return '\n'.join(lines)
+
+    @staticmethod
+    def _join_blocks(blocks):
+        """Join non-empty markdown blocks with blank lines."""
+        clean = [block.strip('\n') for block in blocks if block and block.strip()]
+        return '\n\n'.join(clean) + ('\n' if clean else '')
+
+    def _convert_html_fragment_to_markdown(self, note, content, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title):
+        """Convert one HTML fragment to markdown with the standard post-processing pipeline."""
         note_specific_hash_to_path = {
             hash_val: paths.get(note.guid)
             for hash_val, paths in hash_to_paths.items() if note.guid in paths
         }
+        options_with_context = dict(options)
+        options_with_context["_deleted_guid_to_title"] = deleted_guid_to_title
+        options_with_context["_is_web_clip_note"] = bool(
+            getattr(note.attributes, "sourceURL", "")
+            and "--en-clipped-content" in note.content
+        )
+
+        calendar_mode = self._resolve_calendar_event_mode(options)
+        if calendar_mode == "custom_callout":
+            formatted_content, calendar_events = self._extract_and_replace_calendar_events(content)
+        elif calendar_mode == "remove":
+            formatted_content, calendar_events = self._remove_calendar_events(content), []
+        else:
+            formatted_content, calendar_events = content, []
+
         markdown_content, warnings = self.converter.convert_html_to_markdown(
-            content, 
-            md_properties = [], # actually processed by parent of this
+            formatted_content,
+            md_properties = [],
             tasks = tasks,
             guid_to_path = guid_to_path,
             hash_to_path = note_specific_hash_to_path,
-            options      = options)
+            options      = options_with_context)
 
-        # if warnings:
-        #     for warning in warnings:
-        #         log(logging.WARNING, f"   - {warning}")
+        for idx, event_data in enumerate(calendar_events):
+            placeholder = f'EVERNOTE_CALENDAR_PLACEHOLDER_{idx}'
+            callout_md = self._format_calendar_callout(event_data)
+            markdown_content = markdown_content.replace(placeholder, callout_md)
+
+        markdown_content = self._convert_codeblocks_to_quotes(markdown_content)
+
+        if options_with_context.get("hr_as_h1", False):
+            markdown_content = self._promote_text_hr_to_h1(markdown_content)
+
+        if options_with_context.get("bold_date_log_to_headings", False):
+            add_history = options_with_context.get("date_log_history_heading", False)
+            markdown_content = self._convert_bold_date_log_to_headings(markdown_content, add_history=add_history)
+
+        if options_with_context.get("normalize_header_dates", False):
+            markdown_content = self._normalize_dates_in_headings(markdown_content)
 
         return markdown_content, warnings
+
+    def convert(self, note, content, guid_to_path, path_to_guid, hash_to_paths, tasks, options, deleted_guid_to_title):
+        source_url = getattr(note.attributes, 'sourceURL', '') or ''
+        is_clip = source_url and '--en-clipped-content' in content
+        mode = self._resolve_web_clip_mode(options)
+
+        if mode == "iframe_only":
+            if self._is_web_clip(note):
+                return self._web_clip_iframe_html(options, source_url), []
+            if source_url and '--en-clipped-content' in content:
+                content, placeholder = self._replace_clipped_content_with_iframe(content, source_url)
+                markdown_content, warnings = self._convert_html_fragment_to_markdown(
+                    note, content, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title)
+                iframe_html = self._web_clip_iframe_html(options, source_url)
+                markdown_content = markdown_content.replace(placeholder, iframe_html)
+                return markdown_content, warnings
+            return self._convert_html_fragment_to_markdown(
+                note, content, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title)
+
+        if not is_clip:
+            return self._convert_html_fragment_to_markdown(
+                note, content, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title)
+
+        # Hybrid/content-only modes: preserve archived clipped content as markdown.
+        is_pure = self._is_web_clip(note)
+        user_content, clipped_content = self._split_web_clip_content(content)
+        archived_html = clipped_content or content
+        archived_md, archived_warnings = self._convert_html_fragment_to_markdown(
+            note, archived_html, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title)
+        archived_callout = self._wrap_web_clip_callout(archived_md, options)
+
+        if is_pure:
+            blocks = [archived_callout]
+            if mode == "hybrid" and source_url:
+                blocks.insert(0, self._web_clip_iframe_html(options, source_url))
+            return self._join_blocks(blocks), archived_warnings
+
+        user_md, user_warnings = self._convert_html_fragment_to_markdown(
+            note, user_content, guid_to_path, hash_to_paths, tasks, options, deleted_guid_to_title)
+        blocks = [user_md]
+        if mode == "hybrid" and source_url:
+            blocks.append(self._web_clip_iframe_html(options, source_url))
+        blocks.append(archived_callout)
+        return self._join_blocks(blocks), user_warnings + archived_warnings
+
+    @staticmethod
+    def _promote_text_hr_to_h1(markdown_content):
+        """Convert 'single line text\\n___' to '# text' in markdown output."""
+        return re.sub(
+            r'^([^\n#>!\-\d|_].+)\n___\n?(?=\n|$)',
+            r'# \1\n',
+            markdown_content,
+            flags=re.MULTILINE,
+        )
+
+    _codeblock_quote_languages = {'', 'plaintext'}
+
+    @staticmethod
+    def _convert_codeblocks_to_quotes(markdown_content):
+        """Convert fenced code blocks without a real language to > [!quote] callouts."""
+        convert_langs = Exporter_MD._codeblock_quote_languages
+        lines = markdown_content.split('\n')
+        result = []
+        i = 0
+        while i < len(lines):
+            stripped = lines[i].strip()
+            if stripped.startswith('```'):
+                lang = stripped[3:].strip()
+                if lang in convert_langs:
+                    block = []
+                    i += 1
+                    closed = False
+                    while i < len(lines):
+                        if lines[i].strip() == '```':
+                            closed = True
+                            i += 1
+                            break
+                        block.append(lines[i])
+                        i += 1
+                    if closed:
+                        result.append('> [!quote] ')
+                        for line in block:
+                            s = line.rstrip()
+                            result.append(f'> {s}' if s else '>')
+                        result.append('')
+                    else:
+                        result.append(lines[i - len(block) - 1])
+                        result.extend(block)
+                else:
+                    result.append(lines[i])
+                    i += 1
+                    while i < len(lines):
+                        result.append(lines[i])
+                        if lines[i].strip() == '```':
+                            i += 1
+                            break
+                        i += 1
+            else:
+                result.append(lines[i])
+                i += 1
+        return '\n'.join(result)
+
+    @staticmethod
+    def _convert_bold_date_log_to_headings(markdown_content, add_history=False):
+        """Convert lines starting with **date** or bare date to ## DD MMM YYYY headings."""
+        from datetime import datetime
+
+        def normalize_month(s):
+            return re.sub(r'\bSept\b', 'Sep', s, flags=re.IGNORECASE)
+
+        formats_with_year = (
+            '%d %B %Y', '%d %b %Y',
+            '%B %d, %Y', '%b %d, %Y', '%B %d %Y', '%b %d %Y',
+            '%d/%m/%Y',
+        )
+        formats_no_year = (
+            '%d %B', '%d %b',
+            '%B %d', '%b %d',
+        )
+
+        def try_parse_date(text):
+            text = normalize_month(text.strip())
+            for fmt in formats_with_year:
+                try:
+                    return datetime.strptime(text, fmt)
+                except ValueError:
+                    continue
+            return None
+
+        def try_parse_date_no_year(text):
+            text = normalize_month(text.strip())
+            for fmt in formats_no_year:
+                try:
+                    return datetime.strptime(text, fmt)
+                except ValueError:
+                    continue
+            return None
+
+        _bare_date_dd = re.compile(r'^(\s*)(\d{1,2}\s+\w+\s+\d{4})\b(.*)$')
+        _bare_date_md = re.compile(r'^(\s*)(\w+\s+\d{1,2},?\s+\d{4})\b(.*)$')
+        _bare_date_numeric = re.compile(r'^(\s*)(\d{1,2}/\d{1,2}/\d{4})\b(.*)$')
+        _bare_date_dd_noyear = re.compile(r'^(\s*)(\d{1,2}\s+\w+)\b(.*)$')
+
+        def format_heading(dt, prefix, rest_stripped, level=2):
+            hashes = '#' * level
+            heading = f"{hashes} {dt.day} {dt.strftime('%b %Y')}"
+            if rest_stripped:
+                return f"{prefix}{heading}\n{prefix}{rest_stripped}"
+            return f"{prefix}{heading}"
+
+        def extract_date_and_rest(line):
+            """Try to extract a date from a line. Returns (dt, prefix, rest) or None."""
+            # Bold date: **29 June 2024** rest  or split bold **15 July** **2020** rest
+            m = re.match(r'^(\s*)\*\*([^*]+)\*\*\s*(?:\*\*([^*]+)\*\*)?\s*(.*)$', line)
+            if m:
+                prefix = m.group(1)
+                date_text = m.group(2) + (' ' + m.group(3) if m.group(3) else '')
+                rest = m.group(4)
+                dt = try_parse_date(date_text)
+                if dt:
+                    return dt, prefix, rest.strip()
+                dt = try_parse_date_no_year(date_text)
+                if dt:
+                    return dt, prefix, rest.strip()
+
+            # Bare date with year
+            for pat in (_bare_date_dd, _bare_date_md, _bare_date_numeric):
+                m = pat.match(line)
+                if not m:
+                    continue
+                prefix, date_text, rest = m.group(1), m.group(2), m.group(3)
+                dt = try_parse_date(date_text)
+                if dt:
+                    return dt, prefix, rest.strip()
+
+            # Bare date without year: 26 Aug rest
+            m = _bare_date_dd_noyear.match(line)
+            if m and not line.lstrip().startswith('#'):
+                prefix, date_text, rest = m.group(1), m.group(2), m.group(3)
+                dt = try_parse_date_no_year(date_text)
+                if dt:
+                    return dt, prefix, rest.strip()
+
+            return None
+
+        _date_range_sep = re.compile(r'^[-–—]\s*\d|^to\s+\d', re.IGNORECASE)
+
+        def is_date_range(rest):
+            """Check if rest starts with a range separator followed by a date-like value."""
+            return bool(_date_range_sep.match(rest))
+
+        lines = markdown_content.split('\n')
+
+        # First pass: collect years from all dated lines to build a lookup
+        year_at_line = {}
+        for i, line in enumerate(lines):
+            result = extract_date_and_rest(line)
+            if result and not is_date_range(result[2]) and result[0].year != 1900:
+                year_at_line[i] = result[0].year
+
+        def infer_year(line_idx):
+            """Find the nearest line with a known year."""
+            best_dist = float('inf')
+            best_year = None
+            for idx, year in year_at_line.items():
+                dist = abs(idx - line_idx)
+                if dist < best_dist:
+                    best_dist = dist
+                    best_year = year
+            return best_year
+
+        # Second pass: convert lines
+        _heading_re = re.compile(r'^(#{1,6})\s')
+        out = []
+        current_section_level = 1
+        for i, line in enumerate(lines):
+            hm = _heading_re.match(line)
+            if hm:
+                heading_text = line[len(hm.group(0)):].strip()
+                heading_is_date = try_parse_date(heading_text) is not None
+                if not heading_is_date:
+                    current_section_level = len(hm.group(1))
+
+            result = extract_date_and_rest(line)
+            if result and not is_date_range(result[2]):
+                dt, prefix, rest = result
+                if dt.year == 1900:
+                    year = infer_year(i)
+                    if year:
+                        dt = dt.replace(year=year)
+                    else:
+                        out.append(line)
+                        continue
+                date_level = min(current_section_level + 1, 6)
+                out.append(format_heading(dt, prefix, rest, level=date_level))
+            else:
+                out.append(line)
+
+        if add_history:
+            # Insert a "History" heading before the first date heading that
+            # has no preceding non-date section heading.
+            date_heading_re = re.compile(r'^#{1,6} \d{1,2} \w{3} \d{4}')
+            any_heading_re  = re.compile(r'^#{1,6} ')
+            first_date_idx = None
+            has_prior_heading = False
+            for idx, ln in enumerate(out):
+                if any_heading_re.match(ln) and not date_heading_re.match(ln):
+                    has_prior_heading = True
+                elif date_heading_re.match(ln):
+                    first_date_idx = idx
+                    break
+            if first_date_idx is not None and not has_prior_heading:
+                date_hashes = out[first_date_idx].split(' ', 1)[0]
+                history_level = max(len(date_hashes) - 1, 1)
+                history_heading = f"{'#' * history_level} History"
+                out.insert(first_date_idx, history_heading)
+
+        return '\n'.join(out)
+
+    @staticmethod
+    def _normalize_dates_in_headings(markdown_content):
+        """Normalize any date in a markdown heading to DD MMM YYYY format."""
+        from datetime import datetime
+
+        def normalize_month(s):
+            return re.sub(r'\bSept\b', 'Sep', s, flags=re.IGNORECASE)
+
+        formats = (
+            '%d %B %Y', '%d %b %Y',
+            '%B %d, %Y', '%b %d, %Y', '%B %d %Y', '%b %d %Y',
+            '%Y-%m-%d',
+            '%d/%m/%Y',
+        )
+        month_names = r'(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*'
+        date_patterns = [
+            re.compile(r'(\d{4}-\d{2}-\d{2})'),
+            re.compile(r'(\d{1,2}\s+' + month_names + r'\s+\d{4})', re.IGNORECASE),
+            re.compile(r'(' + month_names + r'\s+\d{1,2},?\s+\d{4})', re.IGNORECASE),
+            re.compile(r'(\d{1,2}/\d{1,2}/\d{4})'),
+        ]
+
+        def try_parse(s):
+            s = normalize_month(s.strip())
+            for fmt in formats:
+                try:
+                    return datetime.strptime(s, fmt)
+                except ValueError:
+                    continue
+            return None
+
+        def format_date(dt):
+            return f"{dt.day} {dt.strftime('%b %Y')}"
+
+        def replace_dates_in_heading(text):
+            for pat in date_patterns:
+                def repl(m):
+                    dt = try_parse(m.group(1))
+                    return format_date(dt) if dt else m.group(0)
+                text = pat.sub(repl, text)
+            return text
+
+        def process_line(line):
+            m = re.match(r'^(#{1,6})\s+(.*)$', line)
+            if not m:
+                return line
+            prefix, rest = m.group(1), m.group(2)
+            return f"{prefix} {replace_dates_in_heading(rest)}"
+
+        return '\n'.join(process_line(line) for line in markdown_content.split('\n'))
 
 
 def export_html():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4>=4.13.4
 prompt-toolkit>=3.0.51
 evernote-backup>=1.13.1
+tzdata>=2024.1


### PR DESCRIPTION
## Summary

- **Calendar events** formatted as nested custom callouts (`[!custom-calendar-event]` with collapsible description)
- **Web clips**: hybrid mode showing iframe + archived content in a collapsed `[!custom-web-clip]` callout as fallback, with configurable `web_clip_mode` (`hybrid`, `iframe_only`, `content_only`)
- **Bold date entries** converted to normalized `## DD MMM YYYY` headings, with yearless date inference and optional history heading insertion
- **Bare/plaintext code blocks** and **HTML blockquotes** converted to `[!quote]` callouts
- **Text + HR promoted to H1**, bold-only lines promoted to headings, heading level normalization, bold stripped from headings, date normalization in headings
- **Global `_resources` folder** with hash-based deduplication and PDF hybrid display mode
- **Forbidden filename characters** replaced with Unicode lookalikes; Unicode non-breaking spaces normalized in links
- **Auto-generated `custom-callout.css`** snippet management; settings grouping in configuration menu
- **12 bug fixes** from code review: operator precedence, IndexError guard, node traversal, mimetypes None guard, deprecated logging.WARN, mutable defaults, statistics.mode exception, sort key lambda, open_db return, fullWidth warning text, negative rowspans, duplicate imports
- **Conversion log improvements**: resolve links to deleted notes by title, GUID-based resource lookup, downgrade web clip warnings to INFO
- **Escape `==` in link labels** to prevent Obsidian highlight parsing

## Test plan

- [ ] Run full conversion on an Evernote backup database and verify output
- [ ] Verify calendar events render correctly as nested callouts in Obsidian
- [ ] Verify web clips show iframe + collapsed archived content in hybrid mode
- [ ] Verify bold date entries are converted to headings with correct format
- [ ] Verify code blocks and blockquotes render as quote callouts
- [ ] Verify heading normalization, bold-to-heading, and HR-to-H1 options work
- [ ] Verify global resources folder deduplication and PDF hybrid mode
- [ ] Verify custom-callout.css is generated correctly based on enabled options
- [ ] Check conversion.log for reduced warning count vs. previous runs


Made with [Cursor](https://cursor.com)