### PR TITLE
Fix export crashes and add execution timer

### DIFF
--- a/evernote2md.py
+++ b/evernote2md.py
@@ -21,10 +21,15 @@ __author__  = "AltoRetrato"
 
 import os
 import re
+import sys
 from   bs4         import BeautifulSoup
 from   typing      import List, Tuple, Dict
 from   statistics  import mode
 from   collections import Counter
+
+# Some Evernote notes have extremely deeply nested <div> elements.
+# Increase the recursion limit to handle them without crashing.
+sys.setrecursionlimit(10000)
 
 
 # Set of block tags in Evernote / HTML (and maybe one or two extras that help with the logic of the code)
@@ -385,11 +390,17 @@ class EvernoteHTMLToMarkdownConverter:
         CENTER     = ":-:"
         RIGHT      = "--:"
 
+        def safe_int(value, default=1):
+            try:
+                return max(1, int(value))
+            except (ValueError, TypeError):
+                return default
+
         # Step 1: Count rows and maximum number of columns
         rows = node.find_all('tr')
         for row in rows:
             cols = row.find_all(["th", "td"])
-            current_cols = sum(int(cell.get("colspan", 1)) for cell in cols)
+            current_cols = sum(safe_int(cell.get("colspan", 1)) for cell in cols)
             max_cols = max(max_cols, current_cols)
 
         # Step 2: Initialize table grid and row_spans
@@ -413,22 +424,25 @@ class EvernoteHTMLToMarkdownConverter:
                 col_num = 0  # Column number of the current cell
                 for cell in cols:
                     # Move past any active rowspans from previous rows
-                    while row_spans[col_num] > 0:
+                    while col_num < max_cols and row_spans[col_num] > 0:
                         row_spans[col_num] -= 1
                         col_num += 1
                     # Get cell content
                     cell_content = self._process_node_children(cell).rstrip("\n")
-                    add_to_grid(col_num, row_num, cell_content, cell)
+                    if col_num < max_cols:
+                        add_to_grid(col_num, row_num, cell_content, cell)
                     # Skip empty cells (with current alignment) if there is a colspan or rowspan
-                    col_span = int(cell.get("colspan", "1"))
-                    row_span = int(cell.get("rowspan", "1"))
+                    col_span = safe_int(cell.get("colspan", "1"))
+                    row_span = safe_int(cell.get("rowspan", "1"))
                     for x in range(col_span):
-                        if row_span > 1:
-                            row_spans[col_num] += row_span -1
+                        if col_num < max_cols:
+                            if row_span > 1:
+                                row_spans[col_num] += row_span -1
                         col_num += 1
                 # Adjust row_spans at the end of a row, if needed
                 for x in range(col_num, max_cols):
-                    row_spans[x] -= 1
+                    if row_spans[x] > 0:
+                        row_spans[x] -= 1
 
             row_num += 1
 

--- a/evernote2md.py
+++ b/evernote2md.py
@@ -540,7 +540,12 @@ class EvernoteHTMLToMarkdownConverter:
             # See https://github.com/AltoRetrato/evernote2obsidian/issues/17
             self.warnings.append(f"Media node without hash: {node}")
             return ""
-        hash_int = int(hash_hex, 16)
+        # Some hashes contain hyphens (UUID format); strip them for hex parsing
+        try:
+            hash_int = int(hash_hex.replace("-", ""), 16)
+        except ValueError:
+            self.warnings.append(f"Invalid media hash format: {hash_hex}")
+            hash_int = None
         if not (file_path := self.hash_to_path.get(hash_int)):
             file_path = hash_hex
             self.warnings.append(f"Path to media hash not found: {hash_hex}")

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -770,6 +770,8 @@ class Exporter:
         if option is None:     return False
         if option == "Cancel": return True
 
+        export_start = datetime.now()
+
         if not (conn := open_db(cfg['database'])):
             return False
 
@@ -1066,6 +1068,15 @@ class Exporter:
                 log(logging.ERROR, error)
 
         conn.close()
+
+        export_end = datetime.now()
+        duration = export_end - export_start
+        hours, remainder = divmod(int(duration.total_seconds()), 3600)
+        minutes, seconds = divmod(remainder, 60)
+        log(IMPORTANT, f"  Start:    {export_start.strftime('%Y-%m-%d %H:%M:%S')}")
+        log(IMPORTANT, f"  End:      {export_end.strftime('%Y-%m-%d %H:%M:%S')}")
+        log(IMPORTANT, f"  Duration: {hours:02d}:{minutes:02d}:{seconds:02d}")
+
         input("\n[ENTER] to continue.")
         return True
 

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -745,6 +745,13 @@ def get_unique_filename(filename, existing_files):
         unique_filename = f"{name}({counter}){extension}"
         counter += 1
 
+    # Truncate the filename component if it exceeds the filesystem limit
+    parts = unique_filename.rsplit("/", 1)
+    if len(parts) == 2:
+        unique_filename = parts[0] + "/" + truncate_filename(parts[1])
+    else:
+        unique_filename = truncate_filename(unique_filename)
+
     return unique_filename
 
 

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -23,6 +23,7 @@ import os
 import re
 import json
 import lzma
+import hashlib
 import pickle
 import logging
 import sqlite3
@@ -426,6 +427,37 @@ def sel_nb_menu():
 def safe_path(path):
     # TO-DO: add in config. a custom character, translation map or regex?
     return re.sub(invalid_chars, "_", path.strip())
+
+
+def truncate_filename(filename, max_bytes=255):
+    """Truncate a filename to fit within the filesystem's max byte limit.
+    Preserves the extension and appends a short hash for uniqueness when truncating."""
+    encoded = filename.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return filename
+
+    # Split into stem and extension
+    if '.' in filename:
+        stem, ext = filename.rsplit('.', 1)
+        ext = '.' + ext
+    else:
+        stem = filename
+        ext = ''
+
+    # Create a short hash from the original full filename for uniqueness
+    hash_suffix = hashlib.md5(filename.encode("utf-8")).hexdigest()[:8]
+    suffix = f"_{hash_suffix}{ext}"
+    suffix_bytes = len(suffix.encode("utf-8"))
+
+    # Truncate stem to fit: max_bytes - suffix length
+    max_stem_bytes = max_bytes - suffix_bytes
+    stem_encoded = stem.encode("utf-8")
+    if len(stem_encoded) > max_stem_bytes:
+        # Truncate at UTF-8 character boundary
+        truncated = stem_encoded[:max_stem_bytes].decode("utf-8", errors="ignore")
+        return truncated + suffix
+
+    return stem + suffix
 
 
 def safe_join(*paths):
@@ -833,11 +865,14 @@ class Exporter:
                     continue
 
                 # Create unique RELATIVE note path from notebook and note title
-                safe_name     = safe_path(f"{note.title}{self.note_ext}")
-                safe_name     = get_unique_filename(safe_name, filenames_set)
+                safe_name     = truncate_filename(safe_path(f"{note.title}{self.note_ext}"))
                 if cfg["links_with_folders"]:
-                      note_path_rel = posix_join(notebook_path_rel, safe_name)
-                else: note_path_rel = safe_name
+                    candidate     = posix_join(notebook_path_rel, safe_name)
+                    note_path_rel = get_unique_filename(candidate, filenames_set)
+                    safe_name     = note_path_rel.rsplit("/", 1)[-1]
+                else:
+                    note_path_rel = get_unique_filename(safe_name, filenames_set)
+                    safe_name     = note_path_rel
                 note_path_abs = posix_join(notebook_path_abs, safe_name)
                 filenames_set.add(note_path_rel.lower())
                 path_to_guid    [note_path_rel] = note.guid
@@ -860,7 +895,7 @@ class Exporter:
                         root = "unnamed"
                     if ext.strip() == "" and resource.mime != "application/octet-stream":
                         ext = mime_ext
-                    fn = safe_path(f"{root}{ext}")
+                    fn = truncate_filename(safe_path(f"{root}{ext}"))
 
                     # TO-DO:
                     # - Allow user to select folder for attachments (one per notebook / one per note ?)


### PR DESCRIPTION
## Summary

Fixes several crashes encountered when exporting a large Evernote database (~80k notes), plus adds export timing output.

### evernote2md.py
- **Table column bounds (KeyError)**: Add bounds checks when colspan/rowspan combinations push column index past `max_cols`
- **Malformed colspan/rowspan (ValueError)**: Add `safe_int()` to handle non-integer attribute values in table cells
- **Deep nesting (RecursionError)**: Increase `sys.setrecursionlimit` to 10000 for notes with extremely nested `<div>` elements
- **UUID media hashes (ValueError)**: Strip hyphens from UUID-format hashes in `<en-media>` nodes before hex parsing

### evernote2obsidian.py
- **Filename truncation (Errno 63)**: Add `truncate_filename()` that limits filenames to 255 bytes (macOS limit), preserving the extension and appending a short MD5 hash for uniqueness
- **Post-dedup truncation**: Apply truncation again after `get_unique_filename()` appends `(1)`, `(2)` suffixes
- **Duplicate note names**: Fix path construction to check full path for uniqueness
- **Export timer**: Log start time, end time, and duration in HH:MM:SS after export completes

## Test plan

- [x] Run full MD export on ~80k note database without crashes
- [x] Verify long filenames are truncated and unique
- [x] Verify tables with complex colspan/rowspan render without errors
- [x] Verify notes with UUID-format media hashes export correctly
- [x] Verify timing output displays after export