### PR TITLE
Fix table conversion crash with rowspan inheritance (closes #22)

### DIFF
--- a/evernote2md.py
+++ b/evernote2md.py
@@ -385,12 +385,28 @@ class EvernoteHTMLToMarkdownConverter:
         CENTER     = ":-:"
         RIGHT      = "--:"
 
-        # Step 1: Count rows and maximum number of columns
+        # Step 1: Count rows and maximum number of columns.
+        # A row's effective width can exceed any single row's colspan-sum
+        # when an earlier row's rowspan extends into it, so we simulate
+        # cell placement (mirroring Step 3's logic) to track the true width.
         rows = node.find_all('tr')
+        pending = {}  # col -> remaining rowspan count, simulation only
         for row in rows:
             cols = row.find_all(["th", "td"])
-            current_cols = sum(int(cell.get("colspan", 1)) for cell in cols)
-            max_cols = max(max_cols, current_cols)
+            if not cols:
+                continue
+            col_num = 0
+            for cell in cols:
+                while pending.get(col_num, 0) > 0:
+                    pending[col_num] -= 1
+                    col_num += 1
+                col_span = int(cell.get("colspan", 1))
+                row_span = int(cell.get("rowspan", 1))
+                for _ in range(col_span):
+                    if row_span > 1:
+                        pending[col_num] = pending.get(col_num, 0) + (row_span - 1)
+                    col_num += 1
+            max_cols = max(max_cols, col_num)
 
         # Step 2: Initialize table grid and row_spans
         grid = [[{"align":LEFT,"content":""} for _ in range(max_cols)] for _ in range(len(rows))]


### PR DESCRIPTION
Closes #22.

## Problem

`_process_table` (in `evernote2md.py`) crashes with `KeyError` when converting a table where a row's effective width — its own cells **plus** columns inherited from an earlier row's `rowspan` — exceeds any single row's `colspan`-sum.

Step 1 computes `max_cols` as `max(sum of colspan in each row)`, which ignores rowspan inheritance. `row_spans` is then initialized with keys `0..max_cols-1`. When Step 3's loop walks past those columns, `row_spans[col_num]` raises `KeyError`.

Minimal reproducer:

```html
<table>
  <tr><td rowspan="2">A</td><td>B</td></tr>
  <tr><td>C</td><td>D</td></tr>
</table>
```

`max_cols` is 2, but row 2 is visually 3 columns wide.

## Fix

Replace Step 1's colspan-only count with a layout simulation that mirrors Step 3's placement logic, so `max_cols` reflects the true visual width. Step 2 (grid + `row_spans` initialization) and Step 3 are unchanged.

The change is contained to `_process_table` — about 19 lines added, 3 removed.

## Verification

Manually exercised the converter against five table shapes:

| Case | Result |
|---|---|
| Bug reproducer (`rowspan=2` + extra cell in next row) | passes — produces `\| A \| B \|  \|` / `\|  \| C \| D \|` |
| `rowspan=3` spanning multiple rows | passes |
| Plain table, no rowspan/colspan (regression) | passes — output unchanged |
| `colspan=2 rowspan=2` combined | passes |
| Single row, single cell (regression) | passes |

The empty cells in rowspan-inherited columns are the expected Markdown rendering (Markdown tables don't support rowspan, so each row gets its own cell row).