### PR TITLE
Handle non-hex hash values in <en-media> tags (closes #24)

### DIFF
--- a/evernote2md.py
+++ b/evernote2md.py
@@ -526,8 +526,14 @@ class EvernoteHTMLToMarkdownConverter:
             # See https://github.com/AltoRetrato/evernote2obsidian/issues/17
             self.warnings.append(f"Media node without hash: {node}")
             return ""
-        hash_int = int(hash_hex, 16)
-        if not (file_path := self.hash_to_path.get(hash_int)):
+        try:
+            hash_int = int(hash_hex, 16)
+            file_path = self.hash_to_path.get(hash_int)
+        except ValueError:
+            # Some notes (e.g. web clips) have non-hex hash values like UUIDs.
+            # Treat as "hash not found" and fall through to the fallback below.
+            file_path = None
+        if not file_path:
             file_path = hash_hex
             self.warnings.append(f"Path to media hash not found: {hash_hex}")
             # TO-DO: this happened on a few (4?) notes where the media hash

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -1058,10 +1058,14 @@ class Exporter_HTML(Exporter):
             result = en_media
             type_  = re.findall('type="([^"]+)"', en_media)[0]
             hash_hex = re.findall('hash="([^"]+)"', en_media)[0]
-            hash_int = int(hash_hex, 16)
-
-            # Find the correct path for this attachment in this specific note
-            note_hash_paths = hash_to_paths.get(hash_int, {})
+            try:
+                hash_int = int(hash_hex, 16)
+                # Find the correct path for this attachment in this specific note
+                note_hash_paths = hash_to_paths.get(hash_int, {})
+            except ValueError:
+                # Some notes (e.g. web clips) have non-hex hash values like UUIDs.
+                # Treat as "hash not found" and fall through to the fallback below.
+                note_hash_paths = {}
             path = note_hash_paths.get(note.guid)
 
             if not path:


### PR DESCRIPTION
Closes #24.

## Problem

Some `<en-media>` tags — most commonly in web clips — carry a UUID-shaped hash rather than the usual MD5 hex string:

```html
<en-media hash="11929ae1-735c-4e28-99a8-624e64ffe5cc" type="image/png"/>
```

Both exporters crash on the dashes:

```
ValueError: invalid literal for int() with base 16: '11929ae1-735c-4e28-99a8-624e64ffe5cc'
```

The empty-hash case (#17) and the "hex but not in resource map" case are already handled. Non-hex hashes are a third case that just isn't guarded.

## Fix

Wrap `int(hash_hex, 16)` in a `try/except ValueError` at both sites so a non-hex hash routes through the existing "Path to media hash not found" fallback, which already uses the hash string as a fallback filename / src.

- `evernote2md.py::_process_media`
- `evernote2obsidian.py::Exporter_HTML.convert::subs_en_media`

Total diff: +16 / -6 across the two files. The empty-hash branch and the standard hex path are unchanged.

## Verification

Manually exercised the converter with these inputs:

| Input | Before | After |
|---|---|---|
| hash UUID (with dashes) | ValueError | warning + uses hash as fallback filename |
| hash non-hex junk | ValueError | warning + uses hash as fallback filename |
| hash hex, missing from map | warning + fallback (regression) | unchanged |
| hash empty | guarded - warning + skip | unchanged |
| hash hex, present in map | normal output | unchanged |

For the HTML exporter (closure inside `Exporter_HTML.convert`), I replicated the post-fix logic in a small harness and confirmed the same five paths route correctly:

- non-hex UUID -> falls into "Path to media hash not found", path = hash string
- non-hex junk -> same
- hex missing from map -> unchanged
- hex present for this note -> returns mapped path
- hex present but only for a different note -> falls back to first available path (existing behavior)