### PR TITLE
Tolerate non-integer colspan/rowspan in tables (closes #26)

### DIFF
--- a/evernote2md.py
+++ b/evernote2md.py
@@ -385,11 +385,19 @@ class EvernoteHTMLToMarkdownConverter:
         CENTER     = ":-:"
         RIGHT      = "--:"
 
+        def parse_span(cell, attr):
+            # HTML spec treats invalid colspan/rowspan values as 1; some
+            # real-world notes use values like "100%" that int() rejects.
+            try:
+                return int(cell.get(attr, 1))
+            except (TypeError, ValueError):
+                return 1
+
         # Step 1: Count rows and maximum number of columns
         rows = node.find_all('tr')
         for row in rows:
             cols = row.find_all(["th", "td"])
-            current_cols = sum(int(cell.get("colspan", 1)) for cell in cols)
+            current_cols = sum(parse_span(cell, "colspan") for cell in cols)
             max_cols = max(max_cols, current_cols)
 
         # Step 2: Initialize table grid and row_spans
@@ -420,8 +428,8 @@ class EvernoteHTMLToMarkdownConverter:
                     cell_content = self._process_node_children(cell).rstrip("\n")
                     add_to_grid(col_num, row_num, cell_content, cell)
                     # Skip empty cells (with current alignment) if there is a colspan or rowspan
-                    col_span = int(cell.get("colspan", "1"))
-                    row_span = int(cell.get("rowspan", "1"))
+                    col_span = parse_span(cell, "colspan")
+                    row_span = parse_span(cell, "rowspan")
                     for x in range(col_span):
                         if row_span > 1:
                             row_spans[col_num] += row_span -1


### PR DESCRIPTION
Closes #26.

## Problem

Some real-world Evernote notes (notably web clips) have `<td>` / `<th>` tags with non-integer `colspan` / `rowspan` attributes — e.g. `colspan="100%"`. Three `int(cell.get(...))` sites in `_process_table` reject them and crash the entire export run:

```
File "evernote2md.py", line 392, in _process_table
    current_cols = sum(int(cell.get("colspan", 1)) for cell in cols)
ValueError: invalid literal for int() with base 10: '100%'
```

The HTML spec says invalid `colspan` / `rowspan` values should be treated as 1.

Minimal reproducer:

```html
<table>
  <tr><td colspan="100%">wide</td></tr>
  <tr><td>x</td></tr>
</table>
```

## Fix

Add a small `parse_span` helper inside `_process_table` that wraps `int(...)` in a `try/except (TypeError, ValueError)` and falls back to 1. Route all three existing parse sites through it:

- Step 1 colspan-sum (line 392)
- Step 3 `col_span` (line 423)
- Step 3 `row_span` (line 424)

Total diff: +11 / -3 in `evernote2md.py`.

## Verification

- Minimal `colspan="100%"` reproducer: now converts cleanly.
- Full export over a 8,795-note DB containing the originally-failing note: 0 crashes, all notes converted.
- Plain table (no spans): regression check passes, output unchanged.

## Note for reviewer

PR #23 introduces a Step 1 placement-simulation block that has the same `int(cell.get(...))` pattern in two more places. If #23 lands, the same `parse_span` helper should be applied there too. Happy to fold #23's simulation into a single follow-up if helpful.