### PR TITLE
Truncate filenames over the filesystem byte limit (closes #11)

### DIFF
--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -24,6 +24,7 @@ import os
 import re
 import json
 import lzma
+import hashlib
 import pickle
 import logging
 import sqlite3
@@ -429,6 +430,35 @@ def safe_path(path):
     return re.sub(invalid_chars, "_", path.strip())
 
 
+def truncate_filename(filename, max_bytes=255):
+    """Truncate a single filename component to fit within the filesystem's
+    per-component byte limit (255 on macOS / most Linux filesystems).
+    Preserves the extension and appends a short hash for uniqueness when
+    truncating, so two long names that share a prefix don't collide.
+    """
+    encoded = filename.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return filename
+
+    if '.' in filename:
+        stem, ext = filename.rsplit('.', 1)
+        ext = '.' + ext
+    else:
+        stem, ext = filename, ''
+
+    hash_suffix  = hashlib.md5(filename.encode("utf-8")).hexdigest()[:8]
+    suffix       = f"_{hash_suffix}{ext}"
+    suffix_bytes = len(suffix.encode("utf-8"))
+
+    max_stem_bytes = max_bytes - suffix_bytes
+    stem_encoded   = stem.encode("utf-8")
+    if len(stem_encoded) > max_stem_bytes:
+        # errors="ignore" trims any partial multi-byte char at the boundary
+        truncated = stem_encoded[:max_stem_bytes].decode("utf-8", errors="ignore")
+        return truncated + suffix
+    return stem + suffix
+
+
 def safe_join(*paths):
     # Apply safe_path() to each argument and then join them
     safe_paths = [safe_path(path) for path in paths if path]
@@ -714,6 +744,13 @@ def get_unique_filename(filename, existing_files):
         unique_filename = f"{name}({counter}){extension}"
         counter += 1
 
+    # Re-truncate the basename if dedup suffixes pushed it back over the limit
+    parts = unique_filename.rsplit("/", 1)
+    if len(parts) == 2:
+        unique_filename = parts[0] + "/" + truncate_filename(parts[1])
+    else:
+        unique_filename = truncate_filename(unique_filename)
+
     return unique_filename
 
 
@@ -834,7 +871,7 @@ class Exporter:
                     continue
 
                 # Create unique RELATIVE note path from notebook and note title
-                safe_name     = safe_path(f"{note.title}{self.note_ext}")
+                safe_name     = truncate_filename(safe_path(f"{note.title}{self.note_ext}"))
                 if cfg["links_with_folders"]:
                     candidate     = posix_join(notebook_path_rel, safe_name)
                     note_path_rel = get_unique_filename(candidate, filenames_set)
@@ -864,7 +901,7 @@ class Exporter:
                         root = "unnamed"
                     if ext.strip() == "" and resource.mime != "application/octet-stream":
                         ext = mime_ext
-                    fn = safe_path(f"{root}{ext}")
+                    fn = truncate_filename(safe_path(f"{root}{ext}"))
 
                     # TO-DO:
                     # - Allow user to select folder for attachments (one per notebook / one per note ?)


### PR DESCRIPTION
Closes #11.

## Problem

Export crashes mid-run with `OSError: [Errno 63] File name too long` whenever a note title or attachment filename exceeds the filesystem's per-component byte limit (255 on macOS / most Linux filesystems):

```
Error saving md/.../The Impact of Psy The Impact of Psychological T chological Trauma on Finance_ Narr auma on Finance_ Narrative Financial Therapy Consider y Considerations in Exploring Complex T ations in Exploring Complex Trauma and Impaired Financial Decis.md:
[Errno 63] File name too long
```

Two real-world triggers in my notebook:

1. **Long article titles** in web-clipped notes — articles whose `<title>` is several hundred bytes long become Markdown filenames over the limit.
2. **"Filenames" derived from URLs** — googleusercontent / cloudfront proxy URLs that Evernote imported as attachment names are routinely 400+ bytes.

## Fix

Add a `truncate_filename(filename, max_bytes=255)` helper that:

- caps each filename component at 255 bytes,
- preserves the extension (so `.md` / `.pdf` / `.jpg` survive),
- appends an 8-char MD5 hash of the original filename as a uniqueness suffix (so two long titles sharing a prefix don't collide),
- handles UTF-8 character boundaries correctly when truncating multi-byte filenames.

Wire it in at three points in `evernote2obsidian.py`:

- Note filename construction in `Exporter.export()`
- Attachment filename construction in `Exporter.export()`
- Inside `get_unique_filename()` (so dedup suffixes `(1)`, `(2)` can't push a near-limit name back over)

Total diff: +39 / -2, contained to `evernote2obsidian.py`. No changes to `evernote2md.py`.

## Verification

Tested against the actual offending paths from my export log:

| Input | In | Out | Under 255B? |
|---|---|---|---|
| googleusercontent ad URL filename | 433 B | 255 B | yes |
| Long PTSD article title | 258 B | 255 B | yes |
| Long Rock Health article title | 258 B | 255 B | yes |
| `short.md` (regression) | 8 B | 8 B (unchanged) | yes |
| Multi-byte UTF-8 (`ŋ` × 153 + `.md`) | 307 B | 254 B (cleanly cut at char boundary) | yes |

After applying, my full export of an 8.7k-note DB completes without `Errno 63`.

## Credit

The `truncate_filename` helper and integration points are extracted from @sandrop's PR #21, which bundles this together with several other crash fixes. I'm separating it into a single-concern PR per [the maintainer's preference for tighter scope](https://github.com/AltoRetrato/evernote2obsidian/pull/18#issuecomment-…). Sandrop is credited as co-author on the commit. Happy to defer to #21 if you'd rather merge it as-is.