### PR TITLE
Note requirement to install evernote3 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ The main files in this project are:
 
 1. Be sure to have Python 3.9 or newer installed on your system.
 
-2. Install `evernote-backup` (to create a local backup of all your Evernote data) and the `prompt_toolkit` module. Using the Command Prompt:
+2. Install `evernote-backup` (to create a local backup of all your Evernote data), the `prompt_toolkit` module, and the `evernote3` module. Using the Command Prompt:
 ```
-pip install evernote-backup prompt_toolkit
+pip install evernote-backup prompt_toolkit evernote3
 ```
 
 3. Create a new folder and download [evernote2obsidian.py](evernote2obsidian.py) and [evernote2md.py](evernote2md.py) into the folder you just created.

--- a/evernote2obsidian.py
+++ b/evernote2obsidian.py
@@ -37,6 +37,7 @@ from   zoneinfo    import ZoneInfo
 from   posixpath   import join as posix_join, normpath as posix_normpath, abspath as posix_abspath
 from   evernote2md import EvernoteHTMLToMarkdownConverter
 try:
+    import evernote  # Not referenced in this code, but pickle.loads needs it # noqa
     from prompt_toolkit.shortcuts import radiolist_dialog, input_dialog, button_dialog
     from prompt_toolkit.shortcuts.dialogs import  _return_none, _create_app
     from prompt_toolkit.application import Application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4>=4.13.4
 prompt-toolkit>=3.0.51
 evernote-backup>=1.13.1
+evernote3>=1.25.14


### PR DESCRIPTION
### Description
I added notes documenting that the evernote3 module must be installed for the package to work properly. 

### Behavior Corrected

If evernote2obsidian.py is run without evernote3 installed, it throws a ModuleNotFound error when it tries to load notes. For example, running "List notes in selected notebooks" throws a ModuleNotFoundError on line 492 of evernote2obsidian.py (in list_db) when it tries to load a note from the database using pickle.loads().

### Changes Made

Add references to evernote3 in
- README.md (installation instructions)
- requirements.txt

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [X] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file

